### PR TITLE
feat: added a step to upload previous medical Reports in the evaluation pipeline.

### DIFF
--- a/research/app/templates/tests.html
+++ b/research/app/templates/tests.html
@@ -1,21 +1,165 @@
 {% extends "base.html" %}
 {% block content %}
     <div class="wizard-step mx-auto">
-        <h2 class="mb-4">Step&nbsp;5 — Previous exams / tests</h2>
-        <form method="post">
-            <input type="hidden" name="sid" value="{{ sid }}" />
-            <div class="mb-3">
-                <label for="previous_tests" class="form-label">
-                    Provide a concise summary of recent lab work or imaging
-                    <small class="text-muted">(enter “none” if not applicable)</small>
-                </label>
-                <textarea class="form-control"
-                          id="previous_tests"
-                          name="previous_tests"
-                          rows="4"
-                          required></textarea>
+        <h2 class="my-4">Upload Test Reports</h2>
+        <!-- Step 1: Question -->
+        <div id="test-files-question"
+             class="{% if patient_data.fhir_reports and patient_data.fhir_reports|length > 0 %}d-none{% else %}d-block{% endif %}">
+            <p>
+                Medical test reports and diagnostic images can provide valuable insights for accurate diagnosis and treatment planning.
+            </p>
+            <div class="mb-3 d-flex fs-1 justify-content-between">
+                <i class="bi bi-file-earmark-pdf"></i>
+                <i class="bi bi-file-earmark-image"></i>
+                <i class="bi bi-file-earmark-medical"></i>
+                <i class="bi bi-clipboard2-pulse"></i>
+                <i class="bi bi-hospital"></i>
+                <i class="bi bi-heart-pulse"></i>
             </div>
-            <button class="btn btn-primary">Next</button>
+            <div class="text-center">
+                <h4 class="mb-4">Do you want to upload test reports for this patient?</h4>
+                <div class="d-flex gap-3 justify-content-center">
+                    <button id="upload-yes" class="btn btn-primary btn-lg" type="button">
+                        <i class="bi bi-check-circle me-2"></i>Yes, Upload Reports
+                    </button>
+                    <button id="upload-no" class="btn btn-outline-secondary btn-lg" type="button">
+                        <i class="bi bi-x-circle me-2"></i>No, Skip This Step
+                    </button>
+                </div>
+            </div>
+        </div>
+        <!-- Step 2: Upload Form (hidden initially) -->
+        <div id="upload-section"
+             class="{% if patient_data.fhir_reports and patient_data.fhir_reports|length > 0 %}d-block{% else %}d-none{% endif %}">
+            <form id="test-files-form" method="post" enctype="multipart/form-data">
+                <input type="hidden" name="patient_id" value="{{ patient_id }}" />
+                <input type="hidden" name="has_reports" id="has_reports_hidden" value="yes" />
+                <input type="hidden" name="action" id="action_field" value="upload" />
+                <span class="text-danger">
+                    {% if error %}{{ error }}{% endif %}
+                </span>
+                <div class="mb-3">
+                    <label class="text-secondary my-1" for="reports" class="form-label">
+                        Please select PDF files or medical images (JPG, JPEG, PNG) containing test reports
+                    </label>
+                    <input id="reports"
+                           class="form-control"
+                           name="reports"
+                           type="file"
+                           multiple
+                           accept=".pdf,image/png,image/jpeg,image/jpg" />
+                </div>
+                {% if patient_data.fhir_reports and patient_data.fhir_reports|length > 0 %}
+                    <p class="my-3 text-secondary">
+                        {{ patient_data.fhir_reports|length }} report
+                        {% if patient_data.fhir_reports|length != 1 %}s{% endif %}
+                        uploaded
+                    </p>
+                    <ul class="list-unstyled mb-3">
+                        {% for report in patient_data.fhir_reports %}
+                            {% if report.filename %}
+                                <li>
+                                    <i class="bi bi-file-earmark-arrow-up me-1"></i>
+                                    {{ report.filename }}
+                                </li>
+                            {% else %}
+                                <li>
+                                    <i class="bi bi-file-earmark-arrow-up me-1"></i>
+                                    [Unnamed file]
+                                </li>
+                            {% endif %}
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+                <div class="d-flex align-items-center gap-2">
+                    <!-- Upload more reports -->
+                    <button type="button" class="btn btn-primary" id="upload-more-btn">
+                        <i class="bi bi-upload me-2"></i>Upload Report
+                    </button>
+                    <!-- Continue to next step -->
+                    <button type="button" class="btn btn-success" id="continue-btn">
+                        <i class="bi bi-arrow-right-circle me-2"></i>Continue to Next Step
+                    </button>
+                    <!-- Loading spinner -->
+                    <div id="loading-indicator"
+                         class="spinner-border text-primary"
+                         role="status"
+                         style="display: none">
+                        <span class="visually-hidden">Processing...</span>
+                    </div>
+                </div>
+            </form>
+        </div>
+        <!-- Skip Form (hidden) -->
+        <form id="skip-form"
+              method="post"
+              action="/tests"
+              enctype="application/x-www-form-urlencoded"
+              style="display: none">
+            <input type="hidden" name="patient_id" value="{{ patient_id }}" />
+            <input type="hidden" name="has_reports" value="no" />
         </form>
     </div>
+{% endblock %}
+{% block scripts %}
+    <script>
+document.addEventListener("DOMContentLoaded", () => {
+    const questionSection = document.getElementById('test-files-question');
+    const uploadSection = document.getElementById('upload-section');
+    const skipForm = document.getElementById('skip-form');
+    const uploadYesBtn = document.getElementById('upload-yes');
+    const uploadNoBtn = document.getElementById('upload-no');
+    const hasReportsHidden = document.getElementById('has_reports_hidden');
+    const form = document.getElementById('test-files-form');
+    const loading = document.getElementById('loading-indicator');
+    const uploadMoreBtn = document.getElementById('upload-more-btn');
+    const continueBtn = document.getElementById('continue-btn');
+    const actionField = document.getElementById('action_field');
+    const reportsInput = document.getElementById('reports');
+
+    // Auto-show upload form if reports exist
+    const hasUploadedReports = {{ 'true' if patient_data.fhir_reports and patient_data.fhir_reports|length > 0 else 'false' }};
+    if (hasUploadedReports) {
+        questionSection.style.display = 'none';
+        uploadSection.style.display = 'block';
+        hasReportsHidden.value = 'yes';
+    }
+
+    // Handle "Yes" button click
+    uploadYesBtn.addEventListener('click', () => {
+        questionSection.classList.add('d-none');
+        uploadSection.classList.remove('d-none');
+        hasReportsHidden.value = 'yes';
+    });
+
+    // Handle "No" button click - skip step
+    uploadNoBtn.addEventListener('click', () => {
+        loading.style.display = 'inline-block';
+        skipForm.submit();
+    });
+
+    // Handle Upload More Reports button
+    uploadMoreBtn.addEventListener('click', () => {
+        if (reportsInput.files.length === 0) {
+            alert('Please select at least one file to upload.');
+            return;
+        }
+
+        actionField.value = 'upload';
+        loading.style.display = 'inline-block';
+        uploadMoreBtn.disabled = true;
+        continueBtn.disabled = true;
+        form.submit();
+    });
+
+    // Handle Continue button (no file validation needed)
+    continueBtn.addEventListener('click', () => {
+        actionField.value = 'continue';
+        loading.style.display = 'inline-block';
+        uploadMoreBtn.disabled = true;
+        continueBtn.disabled = true;
+        form.submit();
+    });
+});
+    </script>
 {% endblock %}


### PR DESCRIPTION


## Pull Request description


- This PR adds a step to add previous medical records in the form of pdf/ images(jpg, jpeg, png) in the evaluation pipeline.
- Provides a option to either upload previous medical records or skip the upload to move on to the next step.
<img width="1905" height="782" alt="image" src="https://github.com/user-attachments/assets/d2ec8e7d-bf3b-4b18-a813-790b3bcf5bb7" />

-  Followed by a "Yes" selection, A interface to upload reports is rendered. 
<img width="1890" height="675" alt="image" src="https://github.com/user-attachments/assets/fd0fbc05-182d-4101-afc5-60844a7591ca" />

-  Reports are converted into FHIR format leveraging the sdx library agents/extraction/medicalreports.py module.
- "Continue to next step" takes us to the next step in the pipeline.
- The FHIR reports are appended into the patient encounter evaluation.

## How to test these changes
- The changes can be tested running the research app.

## Pull Request checklists

This PR is a:
- [x] new feature


About this PR:

- [x] the tests are executed on CI.
- [x] pre-commit hooks were executed locally.

Author's checklist:

- [ ] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more
      complexity.
- [ ] New and old tests passed locally.

## Additional information
- Duplicate uploads of the same file is handled with error a response.
<img width="1898" height="654" alt="image" src="https://github.com/user-attachments/assets/e3a80604-5118-4319-be77-27ee0a1ea631" />

- Unsupported file formats are also handled with a error response
<img width="1902" height="623" alt="image" src="https://github.com/user-attachments/assets/ebea3220-6a8c-462b-9c78-26b1a00b76e1" />


## Reviewer's checklist



```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved
```
