### PR TITLE
Fix: Windows-specific path separator in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,6 +150,6 @@ cython_debug/
 .vscode/
 research/app/data/
 #backend database
-research-poc\backend\backend.db
+research-poc/backend/backend.db
 uvicorn.log
 uvicorn.pid


### PR DESCRIPTION
## Pull Request description

This PR addresses issue #104 by fixing Windows-specific path separator in .gitignore.
The change is scoped to the affected files only and does not introduce any new functionality.

Fixes:#104

## Pull Request checklists

This PR is a:

- [x] bug-fix
- [ ] new feature
- [ ] maintenance

About this PR:

- [ ] it includes tests.
- [ ] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more
      complexity.
- [x] New and old tests passed locally.

## Additional information

Line 153 of .gitignore uses a Windows-specific backslash path separator which will not work correctly on macOS and Linux systems, where forward slashes are required for path separators. Hence, the change.
```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved
```
