### PR TITLE
fix: ensure given data directory exists before the db setup

### DIFF
--- a/.makim.yaml
+++ b/.makim.yaml
@@ -128,7 +128,9 @@ groups:
     tasks:
       setup:
         help: Creates and migrates the database to the latest version
-        run: alembic upgrade head
+        run: |
+          python -c "from pathlib import Path; Path('research/app/data').mkdir(parents=True, exist_ok=True)"
+          alembic upgrade head
       revision:
         help: Autogenerates a new database revision script
         args:


### PR DESCRIPTION

## Pull Request description

This PR resolves issue #106 by updating `makim db.setup` to create the required
data directory automatically, removing the need for manual setup steps.

Fixes: #106 

## How to test these changes

1. Remove `research/app/data` if it already exists.
2. Run `makim db.setup`.
3. Verify the directory is created and migrations complete successfully.


<!-- Modify the options to suit your project. -->

## Pull Request checklists

This PR is a:

- [ ] bug-fix
- [ ] new feature
- [x] maintenance

About this PR:

- [ ] it includes tests.
- [ ] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more
      complexity.
- [ ] New and old tests passed locally.

## Additional information

N/A

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved
```
