### PR TITLE
feat(frontend):add Navbar component with navigation to patient Dahboa…

### DIFF
--- a/research/frontend/src/App.jsx
+++ b/research/frontend/src/App.jsx
@@ -12,7 +12,7 @@ import MedicalReport from "./components/consultation/MedicalReport";
 import Wearable from "./components/consultation/Wearable";
 import Diagnosis from "./components/consultation/Diagnosis";
 import Exam from "./components/consultation/Exam";
-import Completion from "./components/consultation/Confirmation";
+// import Completion from "./components/consultation/Confirmation";
 import { ConsultationProvider } from "./context/ConsultationContext";
 import Confirmation from "./components/consultation/Confirmation";
 import Navbar from "./components/Navbar";

--- a/research/frontend/src/components/Navbar.jsx
+++ b/research/frontend/src/components/Navbar.jsx
@@ -33,7 +33,7 @@ export default function AppNavbar() {
           as={inRouter ? Link : "a"}
           to="/"
           href="/"
-          className="fw-bold text-primary"
+          className="h5 fw-bold text-primary fs-2"
         >
           HiperHealth
         </Navbar.Brand>
@@ -48,7 +48,7 @@ export default function AppNavbar() {
               as={inRouter ? NavLink : "a"}
               to="/"
               href="/"
-              className="fw-semibold text-dark px-3"
+              className="fw-semibold text-dark px-3 small"
             >
               {t("navbar.dashboard", "Patient Dashboard")}
             </Nav.Link>

--- a/research/frontend/src/components/dashboard/Dashboard.jsx
+++ b/research/frontend/src/components/dashboard/Dashboard.jsx
@@ -15,7 +15,6 @@ import { useTranslation } from 'react-i18next';
 import ReactPaginate from 'react-paginate';
 import consultationAPI from '../../services/api';
 import { useConsultation, consultationActions } from '../../context/ConsultationContext';
-import Navbar from '../Navbar';
 
 export default function Dashboard() {
   const navigate = useNavigate();
@@ -157,7 +156,7 @@ export default function Dashboard() {
   const handleDeletePatient = async (patientId, patientName) => {
     if (
       !window.confirm(
-        `Delete patient "${patientName || patientId}"? This action cannot be undone.`
+        `Delete patient "${patientId || patientName}"? This action cannot be undone.`
       )
     ) {
       return;
@@ -201,7 +200,7 @@ export default function Dashboard() {
           {/* Header */}
           <div className="mb-4 d-flex justify-content-between align-items-center">
             <div>
-              <h1 className="display-6 fw-bold text-primary mb-2">
+              <h1 className="h3 fw-bold text-primary mb-2">
                 {t('dashboard.title')}
               </h1>
               <p className="text-muted lead mb-0">


### PR DESCRIPTION
## Pull Request description

This PR adds a Navbar component to the frontend, providing navigation links to the Patient Dashboard and Resume Diagnosis sections. The Navbar is styled with a dedicated CSS file and integrated into the Dashboard view for improved user navigation.


Fixes #130 
Fixes #139 


## How to test these changes

Run the frontend development server
Open the web browser at the local frontend URL (e.g., http://localhost:5173)
Navigate to the Dashboard page and verify the Navbar is visible and links work
Click the links to ensure navigation to Patient Dashboard and Resume Diagnosis


## Additional information
(https://github.com/user-attachments/assets/59ab0eed-e594-4872-91b0-da77c0be3a85)




