### PR TITLE
Fix/wearable upload error

### DIFF
--- a/research/frontend/src/components/consultation/Wearable.jsx
+++ b/research/frontend/src/components/consultation/Wearable.jsx
@@ -138,10 +138,6 @@ export default function Wearable() {
         return;
       }
 
-      // Create FormData for multipart upload
-      const formData = new FormData();
-      formData.append('file', selectedFile);
-
       // Update local state
       dispatch(
         consultationActions.updateWearableData({


### PR DESCRIPTION
## Summary
Uploading wearable data returned HTTP 422 because the upload payload was wrapped in `FormData` twice.  
`Wearable.jsx` built `FormData` and passed it to `uploadWearableData`, and `uploadWearableData` wrapped it again, so backend did not receive a valid file.

## Issue
Fixes:#140

## Fix Implemented
- Pass `selectedFile` directly from `Wearable.jsx`.
- Let `uploadWearableData(patientId, file)` build exactly one `FormData`.

## Test Case
- All test case passed.