### PR TITLE
fix(setup): add frontend npm install step to install-dev.sh

### DIFF
--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -39,9 +39,9 @@ pip install ".[dev]"
 if ! command -v npm >/dev/null 2>&1; then
     echo "Warning: npm not found – skipping frontend dependency installation." >&2
     echo "Install Node.js/npm to run the research frontend." >&2
-elif [ -d "research/frontend" ] && [ -f "research/frontend/package.json" ]; then
+elif [ -d "src/research/frontend" ] && [ -f "src/research/frontend/package.json" ]; then
     echo "Installing frontend dependencies …"
-    (cd research/frontend && { if [ -f package-lock.json ]; then npm ci --no-audit --no-fund; else npm install --no-audit --no-fund; fi; })
+    (cd src/research/frontend && { if [ -f package-lock.json ]; then npm ci --no-audit --no-fund; else npm install --no-audit --no-fund; fi; })
 else
-    echo "Warning: research/frontend missing or no package.json – skipping frontend install." >&2
+    echo "Warning: src/research/frontend missing or no package.json – skipping frontend install." >&2
 fi


### PR DESCRIPTION
## Pull Request description

The `scripts/install-dev.sh` script only installs Python dependencies (`pip install ".[dev]"`), but does not install the npm dependencies required for the research frontend application located in `research/frontend/`.

This causes `makim research.frontend` to fail with `vite: not found` (exit status 127) when a contributor follows the setup instructions in `DEVELOPMENT.md`.

The fix adds an npm install step at the end of the script that:
- Runs `npm install` inside `research/frontend/` after Python dependencies are installed
- Checks for npm availability first, printing a warning instead of failing, so Python-only contributors are unaffected

Fixes #149 

## How to test these changes

- Remove existing frontend node_modules (if any): `rm -rf research/frontend/node_modules`
- Run the install script: `./scripts/install-dev.sh`
- Verify `research/frontend/node_modules/` was created
- Run `makim research.frontend`
- Confirm the frontend starts successfully at `http://127.0.0.1:5173`

## Pull Request checklists

This PR is a:

- [x] bug-fix
- [ ] new feature
- [ ] maintenance

About this PR:

- [ ] it includes tests.
- [ ] The tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [x] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes, and it contains no misspellings.
- [x] The code is well commented, especially in the parts that contain more
      complexity.
- [x] New and old tests passed locally.

## Additional information

**Error before fix:**
```
> hiperhealth-frontend@0.0.0 dev
> vite

sh: 1: vite: not found
subprocess.CalledProcessError: Command '['npm', 'run', 'dev']' returned non-zero exit status 127.
Makim Error #1: ...
```

**Environment tested on:**
- Ubuntu 24.04.3 LTS (WSL2)
- Python 3.13
- Node v24.12.0 / npm 11.8.0
