### PR TITLE
Handling #156

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -34,7 +34,13 @@ jobs:
 
       - name: Install deps
         run: |
+          conda install -y "setuptools<82"
           ./scripts/install-dev.sh
+
+      - name: Ensure setuptools is available immediately before docs build
+        run: |
+          python -m pip install --no-cache-dir --force-reinstall "setuptools<82"
+          python -c "import pkg_resources; print('pkg_resources available')"
 
       - name: Generate documentation with changes from semantic-release
         run: makim --verbose docs.build

--- a/conda/dev-win.yaml
+++ b/conda/dev-win.yaml
@@ -12,4 +12,3 @@ dependencies:
   - uv
   - pip:
       - paginate==0.5.6  # distlib issue
-      - setuptools>=70.1.0  # required for pkg_resources used by mkdocs-macros-plugin

--- a/conda/dev.yaml
+++ b/conda/dev.yaml
@@ -6,10 +6,10 @@ channels:
 dependencies:
   - python >=3.10,<=3.13
   - pip
+  - "setuptools<82"
   - nodejs  # used by semantic-release
   - tesseract
   - libmagic
   - uv
   - pip:
       - paginate==0.5.6  # distlib issue
-      - setuptools>=70.1.0  # required for pkg_resources used by mkdocs-macros-plugin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ authors = [
 license = { text = "BSD 3 Clause" }
 requires-python = ">=3.10,<4"
 dependencies = [
-    "setuptools >=70.1.0",  # required for pkg_resources
     "anamnesisai >=0.4.0",
     "fhir.resources >=8.1.0",
     "pypdf >=5.4.0",
@@ -65,7 +64,7 @@ dev = [
   "ipython >=8",
   "ipykernel >=6.0.0",
   "Jinja2 >=3.1.2",
-  "mkdocs >=1.4.3",
+  "mkdocs >=1.4.3,<2.0",
   "mkdocs-exclude >=1.0.2",
   "mkdocs-jupyter >=0.24.1",
   "mkdocs-literate-nav >=0.6.0",
@@ -77,7 +76,6 @@ dev = [
   "makim ==1.27.0",
   "fastapi >=0.115",
   "python-multipart >=0.0.20",
-  "setuptools >=70.1.0",  # required for pkg_resources used by mkdocs-macros-plugin
 ]
 
 [tool.bandit]

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -6,6 +6,9 @@ SCRIPT_PATH="${BASH_SOURCE:-$0}"
 SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
 cd "$SCRIPT_DIR/.."
 
+# Ensure setuptools < 82 is available for pkg_resources compatibility
+pip install --upgrade "setuptools<82"
+
 # Make uv install into the current interpreter (conda/venv)
 export UV_PYTHON="$(python -c 'import sys; print(sys.executable)')"
 
@@ -33,10 +36,4 @@ case "$OS" in
     ;;
 esac
 
-# Install package with dev dependencies
 pip install ".[dev]"
-
-# CRITICAL: Ensure setuptools is available for pkg_resources
-# Required by mkdocs-macros-plugin. Must be installed AFTER pip install
-# to ensure it's properly registered in the environment.
-pip install --force-reinstall "setuptools>=70.1.0"


### PR DESCRIPTION
Handling the ModuleNotFoundError: No module named 'pkg_resources' error by adding setuptools to the conda environment configuration.