### PR TITLE
fix: pin setuptools<82 and align mkdocs dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ Homepage = "https://github.com/hiperhealth/hiperhealth"
 Issues = "https://github.com/hiperhealth/hiperhealth/issues"
 
 [build-system]
-requires = ["setuptools>=70.1.0,<80.0", "wheel"]
+requires = ["setuptools>=70.1.0,<82", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
@@ -64,12 +64,12 @@ dev = [
   "ipython >=8",
   "ipykernel >=6.0.0",
   "Jinja2 >=3.1.2",
-  "mkdocs >=1.4.3",
+  "mkdocs >=1.3",
   "mkdocs-exclude >=1.0.2",
-  "mkdocs-jupyter >=0.24.1",
-  "mkdocs-literate-nav >=0.6.0",
-  "mkdocs-macros-plugin >=0.7.0,<1",
-  "mkdocs-material >=9.1.15",
+  "mkdocs-jupyter >=0.24.7",
+  "mkdocs-literate-nav >=0.4.1",
+  "mkdocs-macros-plugin >=0.6.3",
+  "mkdocs-material >=8",
   "mkdocstrings >=0.21.2",
   "mkdocstrings-python >= 1.1.2",
   "mkdocs-gen-files >=0.5.0",


### PR DESCRIPTION
## Problem
The CI docs build was failing due to setuptools 82+ removing `pkg_resources`, which mkdocs-macros-plugin depends on. Additionally, our mkdocs dependency versions were overly restrictive.

## Pull Request checklists

This PR is a:

- [ ] bug-fix
- [ ] new feature
- [ ] maintenance

About this PR:

- [ ] it includes tests.
- [ ] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [ ] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more
      complexity.
- [ ] New and old tests passed locally.

## Additional information

<!-- Add any screenshot that helps to show the changes proposed -->

<!-- Add any other extra information that would help to understand the changes proposed by this PR -->

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved
```
