### PR TITLE
fix(research-frontend): correct file size calculation in upload steps

### DIFF
--- a/research/frontend/src/components/consultation/MedicalReport.jsx
+++ b/research/frontend/src/components/consultation/MedicalReport.jsx
@@ -53,7 +53,7 @@ export default function MedicalReport() {
     if (bytes === 0) return '0 Bytes';
     const k = 1024;
     const sizes = ['Bytes', 'KB', 'MB'];
-    const i = Math.floor(Math.log(bytes, k));
+    const i = Math.min(Math.floor(Math.log(bytes) / Math.log(k)), sizes.length - 1);
     return Math.round((bytes / Math.pow(k, i)) * 100) / 100 + ' ' + sizes[i];
   };
 

--- a/research/frontend/src/components/consultation/Wearable.jsx
+++ b/research/frontend/src/components/consultation/Wearable.jsx
@@ -52,7 +52,7 @@ export default function Wearable() {
     if (bytes === 0) return '0 Bytes';
     const k = 1024;
     const sizes = ['Bytes', 'KB', 'MB'];
-    const i = Math.floor(Math.log(bytes, k));
+    const i = Math.min(Math.floor(Math.log(bytes) / Math.log(k)), sizes.length - 1);
     return Math.round((bytes / Math.pow(k, i)) * 100) / 100 + ' ' + sizes[i];
   };
 


### PR DESCRIPTION
<!--

### Notes for PR's Author

- This repository uses an AI bot for reviews. Keep your PR in **Draft** while
  you work. When you’re ready for a review, change the status to **Ready for
  review** to trigger a new review round. If you make additional changes and
  don’t want to trigger the bot, switch the PR back to **Draft**.
- AI-bot comments may not always be accurate. Please review them critically and
  share your feedback; it helps us improve the tool.
- Avoid changing code that is unrelated to your proposal. Keep your PR as short
  as possible to increase the chances of a timely review. Large PRs may not be
  reviewed and may be closed.
- Don’t add unnecessary comments. Your code should be readable and
  self-documenting
  ([guidance](https://google.github.io/styleguide/cppguide.html#Comments)).
- Don’t change core features without prior discussion with the community. Use
  our Discord to discuss ideas, blockers, or issues
  (https://discord.gg/Nu4MdGj9jB).
- Do not include secrets (API keys, tokens, passwords), credentials, or
  sensitive data/PII in code, configs, logs, screenshots, or commit history. If
  something leaks, rotate the credentials immediately, invalidate the old key,
  and note it in the PR so maintainers can assist.
- Do not commit large binaries or generated artifacts. If large datasets are
  needed for tests, prefer small fixtures or programmatic downloads declared in
  makim.yaml (e.g., a task that fetches data at test time). If a large binary is
  unavoidable, discuss first and consider Git LFS.
-->

## Pull Request description

<!-- Describe the purpose of your PR and the changes you have made. -->
Fix file size display showing `0 undefined` in the Medical Reports (Step 5) and Wearable Data (Step 6) upload steps.

`Math.log()` in JavaScript only accepts one argument. The second argument `k` was silently ignored, causing the natural log (base `e`) to be used instead of log base 1024. This produced an out-of-bounds index into the `sizes` array, returning `undefined`.


<!-- Which issue this PR aims to resolve or fix? E.g.:

-->

Fixes #177 

## How to test these changes

<!-- Example:

* run `$ abc -p 1234`
* open the web browser with url localhost:1234
* ...
-->


1. Start the frontend: `npm run dev` (from `research/frontend/`)
2. Navigate to Step 5 (Medical Reports) or Step 6 (Wearable Data)
3. Select any file
4. Observe the file size label — it now shows correctly (e.g. `455 KB`, `219 KB`)
   instead of `0 undefined`

Medical Reports
<img width="1651" height="930" alt="image" src="https://github.com/user-attachments/assets/4ed4a42d-3cc2-41a1-800a-21d84e821f42" />

Wearable Data
<img width="679" height="852" alt="image" src="https://github.com/user-attachments/assets/0fabc75e-c1aa-47a5-bddd-c6c12b68c671" />

<!-- Modify the options to suit your project. -->

## Pull Request checklists

This PR is a:

- [x] bug-fix
- [ ] new feature
- [ ] maintenance

About this PR:

- [ ] it includes tests.
- [ ] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more
      complexity.
- [x] New and old tests passed locally.

## Additional information

<!-- Add any screenshot that helps to show the changes proposed -->

<!-- Add any other extra information that would help to understand the changes proposed by this PR -->


**Files changed:**
- `research/frontend/src/components/consultation/MedicalReport.jsx`
- `research/frontend/src/components/consultation/Wearable.jsx`

**Before:** `0 undefined`
**After:** `455.32 KB`

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved
```
