### PR TITLE
chore: remove deprecated research tasks from .makim.yaml

### DIFF
--- a/.makim.yaml
+++ b/.makim.yaml
@@ -35,26 +35,6 @@ groups:
         run: |
           mkdocs serve --watch docs --config-file mkdocs.yaml
 
-  research:
-    tasks:
-      cli:
-        help: Run the Research CLI
-        dir: research/backend
-        run: python cli.py
-      backend:
-        help: Run the Research backend (FastAPI)
-        dir: research/backend
-        run: uvicorn app.main:app --reload
-      frontend:
-        help: Run the Research frontend (React/Vite)
-        dir: research/frontend
-        run: npm run dev
-      seed:
-        help: Run the script to migrate legacy patient data to the DB
-        dir: scripts
-        run: |
-          python migrate_json_to_db.py
-
   tests:
     tasks:
       linter:


### PR DESCRIPTION
Closes #196 
## Pull Request description

This PR removes the `research` task group (cli, backend, frontend, seed) from `.makim.yaml`. These tasks point to directories that were moved to the `hiperhealth-web` repository during the architectural split. This follows the cleanup initiated in PR #196 


Removing them ensures that `makim --help` accurately reflects the library's current structure and prevents "directory not found" errors for new contributors.

## How to test these changes

- Run `makim --help` and verify the "research" group no longer appears in the output.
- Verify that core library tasks (e.g., `makim tests.unit`) still function as expected.

## Pull Request checklists

This PR is a:

- [ ] bug-fix
- [ ] new feature
- [x] maintenance

About this PR:

- [ ] it includes tests.
- [ ] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [x] pre-commit hooks were executed locally.
- [x] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented (N/A - deletion of dead code).
- [x] New and old tests passed locally.

## Additional information

This is part of the ongoing effort to clean up the core library repository following the split of the web components.