### PR TITLE
feat(safety): Add zero-shot MNLI guardrails to block unsafe LLM output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,9 @@ dev = [
   "makim ==1.27.0",
   "python-multipart >=0.0.20",
 ]
+safety = [
+  "transformers >=4.40,<5",
+]
 
 [tool.bandit]
 exclude_dirs = ["tests"]

--- a/src/hiperhealth/agents/client.py
+++ b/src/hiperhealth/agents/client.py
@@ -3,12 +3,14 @@ title: Shared structured-LLM helper used by all agents.
 summary: |-
   * ``chat_structured`` validates against any Pydantic model.
   * ``chat`` is a convenience wrapper that validates with ``LLMDiagnosis``.
+  * Runs optional safety guard (set HIPERHEALTH_SAFETY_ENABLED=1).
   * Persists every normalized reply under ``data/llm_raw/<sid>_<UTC>.json``.
 """
 
 from __future__ import annotations
 
 import logging
+import os
 import uuid
 
 from datetime import datetime, timezone
@@ -37,6 +39,8 @@ TModel = TypeVar('TModel', bound=BaseModel)
 _log = logging.getLogger(__name__)
 _RAW_DIR = Path('data') / 'llm_raw'
 
+_SAFETY_ENABLED_VALUES = frozenset({'1', 'true', 'yes', 'on'})
+
 
 class LLMResponseValidationError(ValueError):
     """
@@ -60,6 +64,35 @@ def dump_llm_json(text: str, sid: str | None) -> None:
     ts = datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')
     suffix = sid or uuid.uuid4().hex[:8]
     (_RAW_DIR / f'{ts}_{suffix}.json').write_text(text, encoding='utf-8')
+
+
+def _check_safety(result: LLMDiagnosis) -> None:
+    """
+    title: Run topic-guard when HIPERHEALTH_SAFETY_ENABLED is set.
+    summary: |-
+      Imports are lazy so that ``transformers`` remains an optional dependency.
+      Set HIPERHEALTH_SAFETY_ENABLED=1 and install hiperhealth[safety] to
+      activate the guardrail.
+    parameters:
+      result:
+        type: LLMDiagnosis
+        description: Validated LLM output to inspect.
+    raises:
+      ImportError: When safety is enabled but transformers is not installed.
+      UnsafeOutputError: When a banned topic is detected in the output.
+    """
+    if os.getenv('HIPERHEALTH_SAFETY_ENABLED', '').strip().lower() not in (
+        _SAFETY_ENABLED_VALUES
+    ):
+        return
+    try:
+        from hiperhealth.agents.safety.topic_guard import check_output_safety
+    except ImportError as exc:
+        raise ImportError(
+            "HIPERHEALTH_SAFETY_ENABLED is set but 'transformers' is not "
+            "installed. Run: pip install 'hiperhealth[safety]'"
+        ) from exc
+    check_output_safety(result)
 
 
 @retry(
@@ -154,6 +187,9 @@ def chat(
 ) -> LLMDiagnosis:
     """
     title: Send system / user prompts and return a validated ``LLMDiagnosis``.
+    summary: |-
+      Runs the safety guard (if HIPERHEALTH_SAFETY_ENABLED=1) before
+      persisting the response to disk.
     parameters:
       system:
         type: str
@@ -174,14 +210,22 @@ def chat(
       type: LLMDiagnosis
       description: Return value.
     """
-    return chat_structured(
-        system,
-        user,
-        LLMDiagnosis,
-        session_id=session_id,
-        llm=llm,
-        llm_settings=llm_settings,
-    )
+    effective_llm = llm or _get_llm(llm_settings)
+
+    try:
+        result = _call_llm_structured(effective_llm, system, user, LLMDiagnosis)
+    except (ValidationError, TypeError) as exc:
+        raise LLMResponseValidationError(
+            f'LLM response is not valid LLMDiagnosis: {exc}'
+        ) from exc
+
+    # Safety check runs before persistence — unsafe content is never saved.
+    _check_safety(result)
+
+    effective_settings = llm_settings or load_diagnostics_llm_settings()
+    if effective_settings.persist_raw:
+        dump_llm_json(result.model_dump_json(), session_id)
+    return result
 
 
 def _get_llm(llm_settings: LLMSettings | None) -> StructuredLLM:

--- a/src/hiperhealth/agents/client.py
+++ b/src/hiperhealth/agents/client.py
@@ -213,7 +213,9 @@ def chat(
     effective_llm = llm or _get_llm(llm_settings)
 
     try:
-        result = _call_llm_structured(effective_llm, system, user, LLMDiagnosis)
+        result = _call_llm_structured(
+            effective_llm, system, user, LLMDiagnosis
+        )
     except (ValidationError, TypeError) as exc:
         raise LLMResponseValidationError(
             f'LLM response is not valid LLMDiagnosis: {exc}'

--- a/src/hiperhealth/agents/safety/__init__.py
+++ b/src/hiperhealth/agents/safety/__init__.py
@@ -1,0 +1,25 @@
+"""
+title: Safety sub-package for LLM output guardrails.
+"""
+
+from hiperhealth.agents.safety.topic_guard import (
+    DEFAULT_BANNED_TOPICS,
+    DEFAULT_HYP_TEMPLATE,
+    DEFAULT_MODEL,
+    DEFAULT_THRESHOLD,
+    THRESHOLD_MAX,
+    UnsafeOutputError,
+    check_output_safety,
+    detect_banned_topics,
+)
+
+__all__ = [
+    'DEFAULT_BANNED_TOPICS',
+    'DEFAULT_HYP_TEMPLATE',
+    'DEFAULT_MODEL',
+    'DEFAULT_THRESHOLD',
+    'THRESHOLD_MAX',
+    'UnsafeOutputError',
+    'check_output_safety',
+    'detect_banned_topics',
+]

--- a/src/hiperhealth/agents/safety/topic_guard.py
+++ b/src/hiperhealth/agents/safety/topic_guard.py
@@ -48,6 +48,12 @@ class UnsafeOutputError(ValueError):
 
 
 def _get_device_id() -> int:
+    """
+    title: Return GPU device id (0) if CUDA available, else CPU (-1).
+    returns:
+      type: int
+      description: Return value.
+    """
     try:
         import torch
 
@@ -57,6 +63,19 @@ def _get_device_id() -> int:
 
 
 def _env_float(name: str, default: float) -> float:
+    """
+    title: Parse float env var; return default if missing or invalid.
+    parameters:
+      name:
+        type: str
+        description: Value for name.
+      default:
+        type: float
+        description: Value for default.
+    returns:
+      type: float
+      description: Return value.
+    """
     val = os.getenv(name)
     if val is None:
         return default
@@ -67,6 +86,12 @@ def _env_float(name: str, default: float) -> float:
 
 
 def _env_banned_topics() -> tuple[str, ...]:
+    """
+    title: Return banned topics from env or fall back to defaults.
+    returns:
+      type: tuple[str, ...]
+      description: Return value.
+    """
     raw = os.getenv(f'{_ENV_PREFIX}BANNED_TOPICS', '')
     if not raw.strip():
         return DEFAULT_BANNED_TOPICS

--- a/src/hiperhealth/agents/safety/topic_guard.py
+++ b/src/hiperhealth/agents/safety/topic_guard.py
@@ -1,0 +1,190 @@
+"""
+title: Zero-shot MNLI topic guard for LLM output safety.
+summary: |-
+  Detects banned topics (self-harm, violent threats, dosing advice, etc.)
+  via zero-shot classification and raises UnsafeOutputError before the
+  response is persisted or returned from agents.client.chat.
+"""
+
+from __future__ import annotations
+
+import os
+
+from functools import lru_cache
+from typing import Any
+
+from hiperhealth.schema.clinical_outputs import LLMDiagnosis
+
+# ---------------------------------------------------------------------------
+# Named constants
+# ---------------------------------------------------------------------------
+DEFAULT_MODEL: str = 'facebook/bart-large-mnli'
+DEFAULT_THRESHOLD: float = 0.8
+THRESHOLD_MAX: float = 1.0
+DEFAULT_HYP_TEMPLATE: str = 'This text is about {}.'
+DEFAULT_BANNED_TOPICS: tuple[str, ...] = (
+    'self-harm or suicide instructions',
+    'violent threats',
+    'medication dosing advice',
+    'step-by-step treatment plans',
+    'illegal drug use',
+)
+
+_ENV_PREFIX = 'HIPERHEALTH_SAFETY_'
+
+
+class UnsafeOutputError(ValueError):
+    """
+    title: Raised when LLM output contains a banned topic.
+    attributes:
+      hits:
+        type: list[tuple[str, float]]
+        description: Detected (label, score) pairs that exceeded the threshold.
+    """
+
+    def __init__(
+        self, message: str, hits: list[tuple[str, float]]
+    ) -> None:
+        super().__init__(message)
+        self.hits = hits
+
+
+def _get_device_id() -> int:
+    """Return GPU device id (0) when CUDA is available, else CPU (-1)."""
+    try:
+        import torch  # type: ignore[import-untyped]
+
+        return 0 if torch.cuda.is_available() else -1
+    except ImportError:
+        return -1
+
+
+def _env_float(name: str, default: float) -> float:
+    """Parse a float env var; fall back to *default* if missing or invalid."""
+    val = os.getenv(name)
+    if val is None:
+        return default
+    try:
+        return float(val)
+    except ValueError:
+        return default
+
+
+def _env_banned_topics() -> tuple[str, ...]:
+    """Return banned topics from env or fall back to defaults."""
+    raw = os.getenv(f'{_ENV_PREFIX}BANNED_TOPICS', '')
+    if not raw.strip():
+        return DEFAULT_BANNED_TOPICS
+    parsed = tuple(t.strip() for t in raw.split(';') if t.strip())
+    return parsed or DEFAULT_BANNED_TOPICS
+
+
+@lru_cache(maxsize=1)
+def create_topic_classifier(model_name: str) -> Any:
+    """
+    title: Create and cache a zero-shot classification pipeline.
+    parameters:
+      model_name:
+        type: str
+        description: HuggingFace model name for zero-shot classification.
+    returns:
+      type: Any
+      description: transformers zero-shot-classification pipeline.
+    """
+    from transformers import pipeline  # type: ignore[import-untyped]
+
+    return pipeline(
+        'zero-shot-classification',
+        model=model_name,
+        device=_get_device_id(),
+    )
+
+
+def detect_banned_topics(
+    text: str,
+    banned_topics: tuple[str, ...] | None = None,
+    *,
+    threshold: float | None = None,
+    model_name: str | None = None,
+    hypothesis_template: str | None = None,
+) -> list[tuple[str, float]]:
+    """
+    title: Return (label, score) pairs that exceed the safety threshold.
+    parameters:
+      text:
+        type: str
+        description: Text to classify.
+      banned_topics:
+        type: tuple[str, ...] | None
+        description: Labels to test against; defaults to DEFAULT_BANNED_TOPICS.
+      threshold:
+        type: float | None
+        description: Confidence cut-off; env HIPERHEALTH_SAFETY_THRESHOLD.
+      model_name:
+        type: str | None
+        description: HF model name; env HIPERHEALTH_SAFETY_MODEL.
+      hypothesis_template:
+        type: str | None
+        description: NLI hypothesis template; env HIPERHEALTH_SAFETY_HYP_TEMPLATE.
+    returns:
+      type: list[tuple[str, float]]
+      description: Detected hits above threshold.
+    """
+    effective_topics = banned_topics or _env_banned_topics()
+    effective_threshold = (
+        threshold
+        if threshold is not None
+        else _env_float(f'{_ENV_PREFIX}THRESHOLD', DEFAULT_THRESHOLD)
+    )
+    effective_model = model_name or os.getenv(
+        f'{_ENV_PREFIX}MODEL', DEFAULT_MODEL
+    )
+    effective_template = hypothesis_template or os.getenv(
+        f'{_ENV_PREFIX}HYP_TEMPLATE', DEFAULT_HYP_TEMPLATE
+    )
+
+    classifier = create_topic_classifier(effective_model)
+    output = classifier(
+        text,
+        candidate_labels=list(effective_topics),
+        hypothesis_template=effective_template,
+    )
+
+    return [
+        (label, score)
+        for label, score in zip(output['labels'], output['scores'])
+        if score >= effective_threshold
+    ]
+
+
+def check_output_safety(obj: LLMDiagnosis) -> None:
+    """
+    title: Validate *obj* against banned topics; raise UnsafeOutputError on hit.
+    summary: |-
+      Combines summary and options into a single text block, runs zero-shot
+      MNLI classification, and raises UnsafeOutputError if any banned topic
+      exceeds the configured threshold.
+    parameters:
+      obj:
+        type: LLMDiagnosis
+        description: Validated LLM output to inspect.
+    raises:
+      UnsafeOutputError: When a banned topic is detected.
+    """
+    if isinstance(obj.options, dict):
+        options_parts: list[str] = list(obj.options.keys())
+    else:
+        options_parts = list(obj.options or [])
+
+    options_text = '\n'.join(str(p) for p in options_parts)
+    combined = f'{obj.summary}\n{options_text}'.strip()
+    if not combined:
+        return
+
+    hits = detect_banned_topics(combined)
+    if hits:
+        detail = ', '.join(f'{lbl}:{score:.2f}' for lbl, score in hits)
+        raise UnsafeOutputError(
+            f'Unsafe LLM output blocked — banned topics detected: {detail}',
+            hits=hits,
+        )

--- a/src/hiperhealth/agents/safety/topic_guard.py
+++ b/src/hiperhealth/agents/safety/topic_guard.py
@@ -50,9 +50,8 @@ class UnsafeOutputError(ValueError):
 
 
 def _get_device_id() -> int:
-    """Return GPU device id (0) when CUDA is available, else CPU (-1)."""
     try:
-        import torch  # type: ignore[import-untyped]
+        import torch
 
         return 0 if torch.cuda.is_available() else -1
     except ImportError:
@@ -60,7 +59,6 @@ def _get_device_id() -> int:
 
 
 def _env_float(name: str, default: float) -> float:
-    """Parse a float env var; fall back to *default* if missing or invalid."""
     val = os.getenv(name)
     if val is None:
         return default
@@ -71,7 +69,6 @@ def _env_float(name: str, default: float) -> float:
 
 
 def _env_banned_topics() -> tuple[str, ...]:
-    """Return banned topics from env or fall back to defaults."""
     raw = os.getenv(f'{_ENV_PREFIX}BANNED_TOPICS', '')
     if not raw.strip():
         return DEFAULT_BANNED_TOPICS
@@ -91,7 +88,7 @@ def create_topic_classifier(model_name: str) -> Any:
       type: Any
       description: transformers zero-shot-classification pipeline.
     """
-    from transformers import pipeline  # type: ignore[import-untyped]
+    from transformers import pipeline
 
     return pipeline(
         'zero-shot-classification',
@@ -125,7 +122,8 @@ def detect_banned_topics(
         description: HF model name; env HIPERHEALTH_SAFETY_MODEL.
       hypothesis_template:
         type: str | None
-        description: NLI hypothesis template; env HIPERHEALTH_SAFETY_HYP_TEMPLATE.
+        description: |-
+          NLI hypothesis template; env HIPERHEALTH_SAFETY_HYP_TEMPLATE.
     returns:
       type: list[tuple[str, float]]
       description: Detected hits above threshold.
@@ -159,7 +157,8 @@ def detect_banned_topics(
 
 def check_output_safety(obj: LLMDiagnosis) -> None:
     """
-    title: Validate *obj* against banned topics; raise UnsafeOutputError on hit.
+    title: |-
+      Validate *obj* against banned topics; raise UnsafeOutputError on hit.
     summary: |-
       Combines summary and options into a single text block, runs zero-shot
       MNLI classification, and raises UnsafeOutputError if any banned topic

--- a/src/hiperhealth/agents/safety/topic_guard.py
+++ b/src/hiperhealth/agents/safety/topic_guard.py
@@ -38,11 +38,21 @@ class UnsafeOutputError(ValueError):
     title: Raised when LLM output contains a banned topic.
     attributes:
       hits:
-        type: list[tuple[str, float]]
         description: Detected (label, score) pairs that exceeded the threshold.
     """
 
     def __init__(self, message: str, hits: list[tuple[str, float]]) -> None:
+        """
+        title: Initialise with a human-readable message and the hit list.
+        parameters:
+          message:
+            type: str
+            description: Human-readable description of the unsafe content.
+          hits:
+            type: list[tuple[str, float]]
+            description: >-
+              Detected (label, score) pairs that exceeded the threshold.
+        """
         super().__init__(message)
         self.hits = hits
 
@@ -89,7 +99,7 @@ def _env_banned_topics() -> tuple[str, ...]:
     """
     title: Return banned topics from env or fall back to defaults.
     returns:
-      type: tuple[str, ...]
+      type: tuple[str, Ellipsis]
       description: Return value.
     """
     raw = os.getenv(f'{_ENV_PREFIX}BANNED_TOPICS', '')
@@ -135,7 +145,7 @@ def detect_banned_topics(
         type: str
         description: Text to classify.
       banned_topics:
-        type: tuple[str, ...] | None
+        type: tuple[str, Ellipsis] | None
         description: Labels to test against; defaults to DEFAULT_BANNED_TOPICS.
       threshold:
         type: float | None

--- a/src/hiperhealth/agents/safety/topic_guard.py
+++ b/src/hiperhealth/agents/safety/topic_guard.py
@@ -42,9 +42,7 @@ class UnsafeOutputError(ValueError):
         description: Detected (label, score) pairs that exceeded the threshold.
     """
 
-    def __init__(
-        self, message: str, hits: list[tuple[str, float]]
-    ) -> None:
+    def __init__(self, message: str, hits: list[tuple[str, float]]) -> None:
         super().__init__(message)
         self.hits = hits
 
@@ -122,8 +120,7 @@ def detect_banned_topics(
         description: HF model name; env HIPERHEALTH_SAFETY_MODEL.
       hypothesis_template:
         type: str | None
-        description: |-
-          NLI hypothesis template; env HIPERHEALTH_SAFETY_HYP_TEMPLATE.
+        description: NLI template; env HIPERHEALTH_SAFETY_HYP_TEMPLATE.
     returns:
       type: list[tuple[str, float]]
       description: Detected hits above threshold.
@@ -157,8 +154,7 @@ def detect_banned_topics(
 
 def check_output_safety(obj: LLMDiagnosis) -> None:
     """
-    title: |-
-      Validate *obj* against banned topics; raise UnsafeOutputError on hit.
+    title: Validate obj against banned topics; raise UnsafeOutputError on hit.
     summary: |-
       Combines summary and options into a single text block, runs zero-shot
       MNLI classification, and raises UnsafeOutputError if any banned topic

--- a/tests/test_agents_safety.py
+++ b/tests/test_agents_safety.py
@@ -32,7 +32,8 @@ from hiperhealth.schema.clinical_outputs import LLMDiagnosis
 # ---------------------------------------------------------------------------
 _RUN_HF = os.getenv('RUN_HF_TESTS', '').strip().lower() in {'1', 'true', 'yes'}
 _hf_only = pytest.mark.skipif(
-    not _RUN_HF, reason='Requires HF model/network. Set RUN_HF_TESTS=1 to enable.'
+    not _RUN_HF,
+    reason='Requires HF model/network. Set RUN_HF_TESTS=1 to enable.',
 )
 
 
@@ -44,7 +45,6 @@ def _diagnosis(summary: str, options: list[str] | None = None) -> LLMDiagnosis:
 # UnsafeOutputError
 # ---------------------------------------------------------------------------
 def test_unsafe_output_error_carries_hits() -> None:
-    """UnsafeOutputError should expose the (label, score) hits."""
     hits = [('medication dosing advice', 0.92)]
     err = UnsafeOutputError('blocked', hits=hits)
     assert err.hits == hits
@@ -54,9 +54,12 @@ def test_unsafe_output_error_carries_hits() -> None:
 # ---------------------------------------------------------------------------
 # _env_float
 # ---------------------------------------------------------------------------
-def test_env_float_returns_default_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_env_float_returns_default_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.delenv('HIPERHEALTH_SAFETY_THRESHOLD', raising=False)
-    assert _env_float('HIPERHEALTH_SAFETY_THRESHOLD', DEFAULT_THRESHOLD) == DEFAULT_THRESHOLD
+    result = _env_float('HIPERHEALTH_SAFETY_THRESHOLD', DEFAULT_THRESHOLD)
+    assert result == DEFAULT_THRESHOLD
 
 
 def test_env_float_parses_valid_value(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -64,9 +67,12 @@ def test_env_float_parses_valid_value(monkeypatch: pytest.MonkeyPatch) -> None:
     assert _env_float('HIPERHEALTH_SAFETY_THRESHOLD', DEFAULT_THRESHOLD) == 0.6
 
 
-def test_env_float_falls_back_on_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_env_float_falls_back_on_invalid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv('HIPERHEALTH_SAFETY_THRESHOLD', 'not-a-float')
-    assert _env_float('HIPERHEALTH_SAFETY_THRESHOLD', DEFAULT_THRESHOLD) == DEFAULT_THRESHOLD
+    result = _env_float('HIPERHEALTH_SAFETY_THRESHOLD', DEFAULT_THRESHOLD)
+    assert result == DEFAULT_THRESHOLD
 
 
 # ---------------------------------------------------------------------------
@@ -123,7 +129,9 @@ def test_detect_banned_topics_returns_hits_above_threshold() -> None:
         'hiperhealth.agents.safety.topic_guard.create_topic_classifier',
         return_value=mock_clf,
     ):
-        result = detect_banned_topics('take 500mg every 4 hours', threshold=0.8)
+        result = detect_banned_topics(
+            'take 500mg every 4 hours', threshold=0.8
+        )
     assert len(result) == 1
     assert result[0][0] == 'medication dosing advice'
     assert result[0][1] == pytest.approx(0.95)
@@ -167,7 +175,6 @@ def test_check_output_safety_raises_unsafe_output_error_on_hit() -> None:
 
 
 def test_check_output_safety_skips_empty_combined_text() -> None:
-    """Empty summary and options should bypass the classifier entirely."""
     obj = LLMDiagnosis(summary='', options=[])
     called = []
     with patch(
@@ -179,7 +186,6 @@ def test_check_output_safety_skips_empty_combined_text() -> None:
 
 
 def test_check_output_safety_handles_dict_options() -> None:
-    """Options as dict[str, float] should not raise TypeError."""
     obj = LLMDiagnosis(summary='Assessment', options={'pancreatitis': 0.7})
     with patch(
         'hiperhealth.agents.safety.topic_guard.detect_banned_topics',
@@ -195,7 +201,9 @@ class _FakeLLM:
     def __init__(self, result: LLMDiagnosis) -> None:
         self.result = result
 
-    def generate(self, system: str, user: str, output_type: type) -> LLMDiagnosis:
+    def generate(
+        self, system: str, user: str, output_type: type
+    ) -> LLMDiagnosis:
         return self.result
 
 
@@ -246,7 +254,6 @@ def test_chat_safety_blocks_before_persist(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: pytest.TempPathFactory,
 ) -> None:
-    """dump_llm_json must NOT be called when the safety guard raises."""
     monkeypatch.setenv('HIPERHEALTH_SAFETY_ENABLED', '1')
     monkeypatch.setattr(client_mod, '_RAW_DIR', tmp_path)
 
@@ -277,7 +284,6 @@ def test_chat_safety_blocks_before_persist(
 @pytest.mark.hf
 @pytest.mark.integration
 def test_hf_detect_banned_topics_blocks_dosing_advice() -> None:
-    """Real MNLI model should flag dosing advice above default threshold."""
     text = (
         'You should take 500mg of ibuprofen every 4 hours and '
         'no more than 3200mg per day.'
@@ -295,7 +301,6 @@ def test_hf_detect_banned_topics_blocks_dosing_advice() -> None:
 @pytest.mark.hf
 @pytest.mark.integration
 def test_hf_detect_banned_topics_allows_harmless_text() -> None:
-    """Real MNLI model should NOT flag benign clinical summary."""
     text = 'The patient presents with mild upper respiratory symptoms.'
     hits = detect_banned_topics(
         text,

--- a/tests/test_agents_safety.py
+++ b/tests/test_agents_safety.py
@@ -1,0 +1,305 @@
+"""
+title: Tests for LLM output safety guardrails (agents/safety).
+summary: |-
+  Unit tests use monkeypatching — no HF model required.
+  Integration tests (marked @pytest.mark.hf) require RUN_HF_TESTS=1 and
+  network access to download the classification model.
+"""
+
+from __future__ import annotations
+
+import os
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import hiperhealth.agents.client as client_mod
+
+from hiperhealth.agents.safety.topic_guard import (
+    DEFAULT_BANNED_TOPICS,
+    DEFAULT_THRESHOLD,
+    UnsafeOutputError,
+    _env_banned_topics,
+    _env_float,
+    check_output_safety,
+    detect_banned_topics,
+)
+from hiperhealth.schema.clinical_outputs import LLMDiagnosis
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+_RUN_HF = os.getenv('RUN_HF_TESTS', '').strip().lower() in {'1', 'true', 'yes'}
+_hf_only = pytest.mark.skipif(
+    not _RUN_HF, reason='Requires HF model/network. Set RUN_HF_TESTS=1 to enable.'
+)
+
+
+def _diagnosis(summary: str, options: list[str] | None = None) -> LLMDiagnosis:
+    return LLMDiagnosis(summary=summary, options=options or ['option-a'])
+
+
+# ---------------------------------------------------------------------------
+# UnsafeOutputError
+# ---------------------------------------------------------------------------
+def test_unsafe_output_error_carries_hits() -> None:
+    """UnsafeOutputError should expose the (label, score) hits."""
+    hits = [('medication dosing advice', 0.92)]
+    err = UnsafeOutputError('blocked', hits=hits)
+    assert err.hits == hits
+    assert 'blocked' in str(err)
+
+
+# ---------------------------------------------------------------------------
+# _env_float
+# ---------------------------------------------------------------------------
+def test_env_float_returns_default_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv('HIPERHEALTH_SAFETY_THRESHOLD', raising=False)
+    assert _env_float('HIPERHEALTH_SAFETY_THRESHOLD', DEFAULT_THRESHOLD) == DEFAULT_THRESHOLD
+
+
+def test_env_float_parses_valid_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('HIPERHEALTH_SAFETY_THRESHOLD', '0.6')
+    assert _env_float('HIPERHEALTH_SAFETY_THRESHOLD', DEFAULT_THRESHOLD) == 0.6
+
+
+def test_env_float_falls_back_on_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('HIPERHEALTH_SAFETY_THRESHOLD', 'not-a-float')
+    assert _env_float('HIPERHEALTH_SAFETY_THRESHOLD', DEFAULT_THRESHOLD) == DEFAULT_THRESHOLD
+
+
+# ---------------------------------------------------------------------------
+# _env_banned_topics
+# ---------------------------------------------------------------------------
+def test_env_banned_topics_falls_back_to_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv('HIPERHEALTH_SAFETY_BANNED_TOPICS', raising=False)
+    assert _env_banned_topics() == DEFAULT_BANNED_TOPICS
+
+
+def test_env_banned_topics_reads_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv('HIPERHEALTH_SAFETY_BANNED_TOPICS', 'topic-a;topic-b')
+    result = _env_banned_topics()
+    assert result == ('topic-a', 'topic-b')
+
+
+def test_env_banned_topics_ignores_empty_string(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv('HIPERHEALTH_SAFETY_BANNED_TOPICS', '')
+    assert _env_banned_topics() == DEFAULT_BANNED_TOPICS
+
+
+# ---------------------------------------------------------------------------
+# detect_banned_topics — unit (mocked classifier)
+# ---------------------------------------------------------------------------
+def _make_mock_classifier(labels: list[str], scores: list[float]) -> MagicMock:
+    mock = MagicMock()
+    mock.return_value = {'labels': labels, 'scores': scores}
+    return mock
+
+
+def test_detect_banned_topics_returns_empty_when_all_below_threshold() -> None:
+    labels = ['medication dosing advice', 'violent threats']
+    scores = [0.1, 0.2]
+    mock_clf = _make_mock_classifier(labels, scores)
+    with patch(
+        'hiperhealth.agents.safety.topic_guard.create_topic_classifier',
+        return_value=mock_clf,
+    ):
+        result = detect_banned_topics('benign text', threshold=0.8)
+    assert result == []
+
+
+def test_detect_banned_topics_returns_hits_above_threshold() -> None:
+    labels = ['medication dosing advice', 'violent threats']
+    scores = [0.95, 0.3]
+    mock_clf = _make_mock_classifier(labels, scores)
+    with patch(
+        'hiperhealth.agents.safety.topic_guard.create_topic_classifier',
+        return_value=mock_clf,
+    ):
+        result = detect_banned_topics('take 500mg every 4 hours', threshold=0.8)
+    assert len(result) == 1
+    assert result[0][0] == 'medication dosing advice'
+    assert result[0][1] == pytest.approx(0.95)
+
+
+def test_detect_banned_topics_all_hits_when_all_above_threshold() -> None:
+    labels = ['medication dosing advice', 'violent threats']
+    scores = [0.9, 0.85]
+    mock_clf = _make_mock_classifier(labels, scores)
+    with patch(
+        'hiperhealth.agents.safety.topic_guard.create_topic_classifier',
+        return_value=mock_clf,
+    ):
+        result = detect_banned_topics('unsafe text', threshold=0.8)
+    assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# check_output_safety — unit (mocked detect_banned_topics)
+# ---------------------------------------------------------------------------
+def test_check_output_safety_passes_for_harmless_output() -> None:
+    obj = _diagnosis('Possible viral infection.')
+    with patch(
+        'hiperhealth.agents.safety.topic_guard.detect_banned_topics',
+        return_value=[],
+    ):
+        check_output_safety(obj)  # must not raise
+
+
+def test_check_output_safety_raises_unsafe_output_error_on_hit() -> None:
+    obj = _diagnosis('Take 500mg ibuprofen every 4 hours.')
+    hits = [('medication dosing advice', 0.91)]
+    with patch(
+        'hiperhealth.agents.safety.topic_guard.detect_banned_topics',
+        return_value=hits,
+    ):
+        with pytest.raises(UnsafeOutputError) as exc_info:
+            check_output_safety(obj)
+    assert exc_info.value.hits == hits
+    assert 'medication dosing advice' in str(exc_info.value)
+
+
+def test_check_output_safety_skips_empty_combined_text() -> None:
+    """Empty summary and options should bypass the classifier entirely."""
+    obj = LLMDiagnosis(summary='', options=[])
+    called = []
+    with patch(
+        'hiperhealth.agents.safety.topic_guard.detect_banned_topics',
+        side_effect=lambda *a, **kw: called.append(True) or [],
+    ):
+        check_output_safety(obj)
+    assert called == []
+
+
+def test_check_output_safety_handles_dict_options() -> None:
+    """Options as dict[str, float] should not raise TypeError."""
+    obj = LLMDiagnosis(summary='Assessment', options={'pancreatitis': 0.7})
+    with patch(
+        'hiperhealth.agents.safety.topic_guard.detect_banned_topics',
+        return_value=[],
+    ):
+        check_output_safety(obj)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# client integration — safety guard enabled/disabled
+# ---------------------------------------------------------------------------
+class _FakeLLM:
+    def __init__(self, result: LLMDiagnosis) -> None:
+        self.result = result
+
+    def generate(self, system: str, user: str, output_type: type) -> LLMDiagnosis:
+        return self.result
+
+
+def test_chat_skips_safety_guard_when_env_not_set(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pytest.TempPathFactory,
+) -> None:
+    monkeypatch.delenv('HIPERHEALTH_SAFETY_ENABLED', raising=False)
+    monkeypatch.setattr(client_mod, '_RAW_DIR', tmp_path)
+
+    fake_llm = _FakeLLM(LLMDiagnosis(summary='ok', options=['a']))
+    monkeypatch.setattr(client_mod, 'dump_llm_json', lambda *_: None)
+
+    guard_called = []
+    with patch(
+        'hiperhealth.agents.safety.topic_guard.check_output_safety',
+        side_effect=lambda obj: guard_called.append(obj),
+    ):
+        client_mod.chat('sys', 'usr', llm=fake_llm)
+
+    assert guard_called == []
+
+
+def test_chat_applies_safety_guard_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pytest.TempPathFactory,
+) -> None:
+    monkeypatch.setenv('HIPERHEALTH_SAFETY_ENABLED', '1')
+    monkeypatch.setattr(client_mod, '_RAW_DIR', tmp_path)
+
+    result = LLMDiagnosis(summary='ok', options=['a'])
+    fake_llm = _FakeLLM(result)
+    monkeypatch.setattr(client_mod, 'dump_llm_json', lambda *_: None)
+
+    guard_called = []
+
+    with patch(
+        'hiperhealth.agents.client._check_safety',
+        side_effect=lambda obj: guard_called.append(obj),
+    ):
+        client_mod.chat('sys', 'usr', llm=fake_llm)
+
+    assert len(guard_called) == 1
+    assert guard_called[0] is result
+
+
+def test_chat_safety_blocks_before_persist(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pytest.TempPathFactory,
+) -> None:
+    """dump_llm_json must NOT be called when the safety guard raises."""
+    monkeypatch.setenv('HIPERHEALTH_SAFETY_ENABLED', '1')
+    monkeypatch.setattr(client_mod, '_RAW_DIR', tmp_path)
+
+    fake_llm = _FakeLLM(
+        LLMDiagnosis(summary='Take 500mg every 4h', options=['dosing'])
+    )
+    dump_called = []
+    monkeypatch.setattr(
+        client_mod, 'dump_llm_json', lambda *_: dump_called.append(True)
+    )
+
+    with patch(
+        'hiperhealth.agents.client._check_safety',
+        side_effect=UnsafeOutputError(
+            'blocked', hits=[('medication dosing advice', 0.95)]
+        ),
+    ):
+        with pytest.raises(UnsafeOutputError):
+            client_mod.chat('sys', 'usr', llm=fake_llm)
+
+    assert dump_called == []
+
+
+# ---------------------------------------------------------------------------
+# HF integration tests — only run when RUN_HF_TESTS=1
+# ---------------------------------------------------------------------------
+@_hf_only
+@pytest.mark.hf
+@pytest.mark.integration
+def test_hf_detect_banned_topics_blocks_dosing_advice() -> None:
+    """Real MNLI model should flag dosing advice above default threshold."""
+    text = (
+        'You should take 500mg of ibuprofen every 4 hours and '
+        'no more than 3200mg per day.'
+    )
+    hits = detect_banned_topics(
+        text,
+        banned_topics=('medication dosing advice', 'self-harm'),
+        threshold=0.5,
+    )
+    labels = [lbl for lbl, _ in hits]
+    assert 'medication dosing advice' in labels
+
+
+@_hf_only
+@pytest.mark.hf
+@pytest.mark.integration
+def test_hf_detect_banned_topics_allows_harmless_text() -> None:
+    """Real MNLI model should NOT flag benign clinical summary."""
+    text = 'The patient presents with mild upper respiratory symptoms.'
+    hits = detect_banned_topics(
+        text,
+        banned_topics=('medication dosing advice', 'self-harm'),
+        threshold=0.8,
+    )
+    assert hits == []

--- a/tests/test_agents_safety.py
+++ b/tests/test_agents_safety.py
@@ -36,7 +36,22 @@ _hf_only = pytest.mark.skipif(
 )
 
 
-def _diagnosis(summary: str, options: list[str] | None = None) -> LLMDiagnosis:
+def _diagnosis(
+    summary: str, options: list[str] | None = None
+) -> LLMDiagnosis:
+    """
+    title: Build a minimal LLMDiagnosis fixture for testing.
+    parameters:
+      summary:
+        type: str
+        description: Patient summary text.
+      options:
+        type: list[str] | None
+        description: Differential options; defaults to ['option-a'].
+    returns:
+      type: LLMDiagnosis
+      description: Constructed LLMDiagnosis fixture.
+    """
     return LLMDiagnosis(summary=summary, options=options or ['option-a'])
 
 
@@ -44,6 +59,9 @@ def _diagnosis(summary: str, options: list[str] | None = None) -> LLMDiagnosis:
 # UnsafeOutputError
 # ---------------------------------------------------------------------------
 def test_unsafe_output_error_carries_hits() -> None:
+    """
+    title: UnsafeOutputError should store hits and include message in str.
+    """
     hits = [('medication dosing advice', 0.92)]
     err = UnsafeOutputError('blocked', hits=hits)
     assert err.hits == hits
@@ -56,12 +74,28 @@ def test_unsafe_output_error_carries_hits() -> None:
 def test_env_float_returns_default_when_unset(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """
+    title: _env_float returns the default when env var is absent.
+    parameters:
+      monkeypatch:
+        type: pytest.MonkeyPatch
+        description: Value for monkeypatch.
+    """
     monkeypatch.delenv('HIPERHEALTH_SAFETY_THRESHOLD', raising=False)
     result = _env_float('HIPERHEALTH_SAFETY_THRESHOLD', DEFAULT_THRESHOLD)
     assert result == DEFAULT_THRESHOLD
 
 
-def test_env_float_parses_valid_value(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_env_float_parses_valid_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    title: _env_float parses a valid float string from the environment.
+    parameters:
+      monkeypatch:
+        type: pytest.MonkeyPatch
+        description: Value for monkeypatch.
+    """
     monkeypatch.setenv('HIPERHEALTH_SAFETY_THRESHOLD', '0.6')
     assert _env_float('HIPERHEALTH_SAFETY_THRESHOLD', DEFAULT_THRESHOLD) == 0.6
 
@@ -69,6 +103,13 @@ def test_env_float_parses_valid_value(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_env_float_falls_back_on_invalid(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """
+    title: _env_float falls back to default when env var is not a number.
+    parameters:
+      monkeypatch:
+        type: pytest.MonkeyPatch
+        description: Value for monkeypatch.
+    """
     monkeypatch.setenv('HIPERHEALTH_SAFETY_THRESHOLD', 'not-a-float')
     result = _env_float('HIPERHEALTH_SAFETY_THRESHOLD', DEFAULT_THRESHOLD)
     assert result == DEFAULT_THRESHOLD
@@ -80,6 +121,13 @@ def test_env_float_falls_back_on_invalid(
 def test_env_banned_topics_falls_back_to_defaults(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """
+    title: _env_banned_topics returns defaults when env var is absent.
+    parameters:
+      monkeypatch:
+        type: pytest.MonkeyPatch
+        description: Value for monkeypatch.
+    """
     monkeypatch.delenv('HIPERHEALTH_SAFETY_BANNED_TOPICS', raising=False)
     assert _env_banned_topics() == DEFAULT_BANNED_TOPICS
 
@@ -87,6 +135,13 @@ def test_env_banned_topics_falls_back_to_defaults(
 def test_env_banned_topics_reads_from_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """
+    title: _env_banned_topics parses semicolon-separated topics from env.
+    parameters:
+      monkeypatch:
+        type: pytest.MonkeyPatch
+        description: Value for monkeypatch.
+    """
     monkeypatch.setenv('HIPERHEALTH_SAFETY_BANNED_TOPICS', 'topic-a;topic-b')
     result = _env_banned_topics()
     assert result == ('topic-a', 'topic-b')
@@ -95,6 +150,13 @@ def test_env_banned_topics_reads_from_env(
 def test_env_banned_topics_ignores_empty_string(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """
+    title: _env_banned_topics falls back to defaults when env var is empty.
+    parameters:
+      monkeypatch:
+        type: pytest.MonkeyPatch
+        description: Value for monkeypatch.
+    """
     monkeypatch.setenv('HIPERHEALTH_SAFETY_BANNED_TOPICS', '')
     assert _env_banned_topics() == DEFAULT_BANNED_TOPICS
 
@@ -102,13 +164,33 @@ def test_env_banned_topics_ignores_empty_string(
 # ---------------------------------------------------------------------------
 # detect_banned_topics — unit (mocked classifier)
 # ---------------------------------------------------------------------------
-def _make_mock_classifier(labels: list[str], scores: list[float]) -> MagicMock:
+def _make_mock_classifier(
+    labels: list[str], scores: list[float]
+) -> MagicMock:
+    """
+    title: Build a mock classifier returning fixed labels and scores.
+    parameters:
+      labels:
+        type: list[str]
+        description: Classification labels to return.
+      scores:
+        type: list[float]
+        description: Corresponding confidence scores to return.
+    returns:
+      type: MagicMock
+      description: Configured mock classifier callable.
+    """
     mock = MagicMock()
     mock.return_value = {'labels': labels, 'scores': scores}
     return mock
 
 
-def test_detect_banned_topics_returns_empty_when_all_below_threshold() -> None:
+def test_detect_banned_topics_returns_empty_when_all_below_threshold() -> (
+    None
+):
+    """
+    title: detect_banned_topics returns [] when all scores are below threshold.
+    """
     labels = ['medication dosing advice', 'violent threats']
     scores = [0.1, 0.2]
     mock_clf = _make_mock_classifier(labels, scores)
@@ -121,6 +203,9 @@ def test_detect_banned_topics_returns_empty_when_all_below_threshold() -> None:
 
 
 def test_detect_banned_topics_returns_hits_above_threshold() -> None:
+    """
+    title: detect_banned_topics returns only labels that exceed the threshold.
+    """
     labels = ['medication dosing advice', 'violent threats']
     scores = [0.95, 0.3]
     mock_clf = _make_mock_classifier(labels, scores)
@@ -137,6 +222,9 @@ def test_detect_banned_topics_returns_hits_above_threshold() -> None:
 
 
 def test_detect_banned_topics_all_hits_when_all_above_threshold() -> None:
+    """
+    title: detect_banned_topics returns all labels when all exceed threshold.
+    """
     labels = ['medication dosing advice', 'violent threats']
     scores = [0.9, 0.85]
     mock_clf = _make_mock_classifier(labels, scores)
@@ -152,6 +240,9 @@ def test_detect_banned_topics_all_hits_when_all_above_threshold() -> None:
 # check_output_safety — unit (mocked detect_banned_topics)
 # ---------------------------------------------------------------------------
 def test_check_output_safety_passes_for_harmless_output() -> None:
+    """
+    title: check_output_safety does not raise when no banned topic is found.
+    """
     obj = _diagnosis('Possible viral infection.')
     with patch(
         'hiperhealth.agents.safety.topic_guard.detect_banned_topics',
@@ -161,6 +252,9 @@ def test_check_output_safety_passes_for_harmless_output() -> None:
 
 
 def test_check_output_safety_raises_unsafe_output_error_on_hit() -> None:
+    """
+    title: check_output_safety raises UnsafeOutputError when a hit is found.
+    """
     obj = _diagnosis('Take 500mg ibuprofen every 4 hours.')
     hits = [('medication dosing advice', 0.91)]
     with patch(
@@ -174,6 +268,10 @@ def test_check_output_safety_raises_unsafe_output_error_on_hit() -> None:
 
 
 def test_check_output_safety_skips_empty_combined_text() -> None:
+    """
+    title: >-
+      check_output_safety skips classification when combined text is empty.
+    """
     obj = LLMDiagnosis(summary='', options=[])
     called = []
     with patch(
@@ -185,6 +283,9 @@ def test_check_output_safety_skips_empty_combined_text() -> None:
 
 
 def test_check_output_safety_handles_dict_options() -> None:
+    """
+    title: check_output_safety handles dict-style options without raising.
+    """
     obj = LLMDiagnosis(summary='Assessment', options={'pancreatitis': 0.7})
     with patch(
         'hiperhealth.agents.safety.topic_guard.detect_banned_topics',
@@ -197,12 +298,42 @@ def test_check_output_safety_handles_dict_options() -> None:
 # client integration — safety guard enabled/disabled
 # ---------------------------------------------------------------------------
 class _FakeLLM:
+    """
+    title: Minimal LLM double that returns a fixed LLMDiagnosis.
+    attributes:
+      result:
+        description: Fixed diagnosis to return from generate().
+    """
+
     def __init__(self, result: LLMDiagnosis) -> None:
+        """
+        title: Initialise with the fixed diagnosis to return.
+        parameters:
+          result:
+            type: LLMDiagnosis
+            description: Diagnosis to return from generate().
+        """
         self.result = result
 
     def generate(
         self, system: str, user: str, output_type: type
     ) -> LLMDiagnosis:
+        """
+        title: Return the fixed result regardless of inputs.
+        parameters:
+          system:
+            type: str
+            description: System prompt (ignored).
+          user:
+            type: str
+            description: User message (ignored).
+          output_type:
+            type: type
+            description: Expected output type (ignored).
+        returns:
+          type: LLMDiagnosis
+          description: Fixed diagnosis result.
+        """
         return self.result
 
 
@@ -210,6 +341,16 @@ def test_chat_skips_safety_guard_when_env_not_set(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: pytest.TempPathFactory,
 ) -> None:
+    """
+    title: chat() should not invoke the safety guard when env var is unset.
+    parameters:
+      monkeypatch:
+        type: pytest.MonkeyPatch
+        description: Value for monkeypatch.
+      tmp_path:
+        type: pytest.TempPathFactory
+        description: Value for tmp_path.
+    """
     monkeypatch.delenv('HIPERHEALTH_SAFETY_ENABLED', raising=False)
     monkeypatch.setattr(client_mod, '_RAW_DIR', tmp_path)
 
@@ -230,6 +371,16 @@ def test_chat_applies_safety_guard_when_enabled(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: pytest.TempPathFactory,
 ) -> None:
+    """
+    title: chat() should invoke _check_safety once when env var is set to 1.
+    parameters:
+      monkeypatch:
+        type: pytest.MonkeyPatch
+        description: Value for monkeypatch.
+      tmp_path:
+        type: pytest.TempPathFactory
+        description: Value for tmp_path.
+    """
     monkeypatch.setenv('HIPERHEALTH_SAFETY_ENABLED', '1')
     monkeypatch.setattr(client_mod, '_RAW_DIR', tmp_path)
 
@@ -253,6 +404,16 @@ def test_chat_safety_blocks_before_persist(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: pytest.TempPathFactory,
 ) -> None:
+    """
+    title: chat() should raise UnsafeOutputError before persisting output.
+    parameters:
+      monkeypatch:
+        type: pytest.MonkeyPatch
+        description: Value for monkeypatch.
+      tmp_path:
+        type: pytest.TempPathFactory
+        description: Value for tmp_path.
+    """
     monkeypatch.setenv('HIPERHEALTH_SAFETY_ENABLED', '1')
     monkeypatch.setattr(client_mod, '_RAW_DIR', tmp_path)
 
@@ -283,6 +444,9 @@ def test_chat_safety_blocks_before_persist(
 @pytest.mark.hf
 @pytest.mark.integration
 def test_hf_detect_banned_topics_blocks_dosing_advice() -> None:
+    """
+    title: HF model should flag explicit medication dosing advice as unsafe.
+    """
     text = (
         'You should take 500mg of ibuprofen every 4 hours and '
         'no more than 3200mg per day.'
@@ -300,6 +464,9 @@ def test_hf_detect_banned_topics_blocks_dosing_advice() -> None:
 @pytest.mark.hf
 @pytest.mark.integration
 def test_hf_detect_banned_topics_allows_harmless_text() -> None:
+    """
+    title: HF model should not flag innocuous clinical text as unsafe.
+    """
     text = 'The patient presents with mild upper respiratory symptoms.'
     hits = detect_banned_topics(
         text,

--- a/tests/test_agents_safety.py
+++ b/tests/test_agents_safety.py
@@ -36,9 +36,7 @@ _hf_only = pytest.mark.skipif(
 )
 
 
-def _diagnosis(
-    summary: str, options: list[str] | None = None
-) -> LLMDiagnosis:
+def _diagnosis(summary: str, options: list[str] | None = None) -> LLMDiagnosis:
     """
     title: Build a minimal LLMDiagnosis fixture for testing.
     parameters:
@@ -164,9 +162,7 @@ def test_env_banned_topics_ignores_empty_string(
 # ---------------------------------------------------------------------------
 # detect_banned_topics — unit (mocked classifier)
 # ---------------------------------------------------------------------------
-def _make_mock_classifier(
-    labels: list[str], scores: list[float]
-) -> MagicMock:
+def _make_mock_classifier(labels: list[str], scores: list[float]) -> MagicMock:
     """
     title: Build a mock classifier returning fixed labels and scores.
     parameters:
@@ -185,9 +181,7 @@ def _make_mock_classifier(
     return mock
 
 
-def test_detect_banned_topics_returns_empty_when_all_below_threshold() -> (
-    None
-):
+def test_detect_banned_topics_returns_empty_when_all_below_threshold() -> None:
     """
     title: detect_banned_topics returns [] when all scores are below threshold.
     """

--- a/tests/test_agents_safety.py
+++ b/tests/test_agents_safety.py
@@ -12,9 +12,8 @@ import os
 
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 import hiperhealth.agents.client as client_mod
+import pytest
 
 from hiperhealth.agents.safety.topic_guard import (
     DEFAULT_BANNED_TOPICS,


### PR DESCRIPTION
Closes #61

Hey! This PR adds a safety guard that checks the AI's response for dangerous content (like dosing instructions, self-harm, threats) before it ever leaves the chat function or gets saved to disk.

It uses zero-shot text classification (`facebook/bart-large-mnli` by default) to detect banned topics. If something unsafe is detected, it raises an error immediately and the bad response is never returned or stored.

**Key design decisions:**
- The guard is **off by default** — set `HIPERHEALTH_SAFETY_ENABLED=1` to turn it on. No existing behaviour is changed.
- `transformers` is an **optional install** (`pip install 'hiperhealth[safety]'`), so regular users don't pull in heavy ML dependencies.
- Everything (model, threshold, banned topics) is configurable via env vars.

This is a fresh implementation that addresses all the review feedback from the previous attempt in PR #48 — correct folder (`agents/safety/` not `guards/`), no monkey-patching, no magic numbers, and HF tests only run when you explicitly set `RUN_HF_TESTS=1`.

## How to test these changes

```bash
# Fast unit tests — no network, no model download needed
pytest tests/test_agents_safety.py -v

# Full integration tests with real HF model (needs internet)
pip install 'hiperhealth[safety]'
RUN_HF_TESTS=1 pytest tests/test_agents_safety.py -m hf -v
\```

## Pull Request checklists

This PR is a:

- [ ] bug-fix
- [x] new feature
- [ ] maintenance

About this PR:

- [x] it includes tests.
- [x] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [x] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more complexity.
- [x] New and old tests passed locally.

## Additional information

| Variable | Default | What it does |
|---|---|---|
| `HIPERHEALTH_SAFETY_ENABLED` | off | Set to `1` to activate the guard |
| `HIPERHEALTH_SAFETY_MODEL` | `facebook/bart-large-mnli` | Which HF model to use |
| `HIPERHEALTH_SAFETY_THRESHOLD` | `0.8` | Confidence level to block a topic |
| `HIPERHEALTH_SAFETY_BANNED_TOPICS` | 5 defaults | Semicolon-separated list of banned topics |

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved
```
