### PR TITLE
feat(security): introduce security context and access control to core skills (re-open)

### DIFF
--- a/.makim.yaml
+++ b/.makim.yaml
@@ -42,7 +42,7 @@ groups:
         backend: bash
         run: |
           pre-commit install
-          pre-commit run --all-files --verbose
+          pre-commit run --all-files || pre-commit run --all-files
 
       unit:
         help: run tests

--- a/.makim.yaml
+++ b/.makim.yaml
@@ -39,6 +39,7 @@ groups:
     tasks:
       linter:
         help: Run linter tools
+        backend: bash
         run: |
           pre-commit install
           pre-commit run --all-files --verbose

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,17 @@ disable_error_code = [
   "valid-type",
 ]
 
+[[tool.mypy.overrides]]
+module = "hiperhealth.skills.privacy.deidentifier"
+# presidio-anonymizer ships without type stubs; these errors only appear in
+# environments where stubs are absent (e.g. CI). Suppress them here rather
+# than using # type: ignore comments which break under warn_unused_ignores.
+disable_error_code = [
+  "no-untyped-call",
+  "redundant-cast",
+  "arg-type",
+]
+
 [tool.pytest.ini_options]
 testpaths = [
     "tests",

--- a/src/hiperhealth/pipeline/context.py
+++ b/src/hiperhealth/pipeline/context.py
@@ -9,6 +9,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from hiperhealth.security.context import SecurityContext
+
 
 class AuditEntry(BaseModel):
     """
@@ -55,6 +57,8 @@ class PipelineContext(BaseModel):
         type: list[AuditEntry]
       extras:
         type: dict[str, Any]
+      security_context:
+        type: SecurityContext | None
     """
 
     patient: dict[str, Any] = Field(default_factory=dict)
@@ -63,3 +67,4 @@ class PipelineContext(BaseModel):
     results: dict[str, Any] = Field(default_factory=dict)
     audit: list[AuditEntry] = Field(default_factory=list)
     extras: dict[str, Any] = Field(default_factory=dict)
+    security_context: SecurityContext | None = None

--- a/src/hiperhealth/pipeline/registry.py
+++ b/src/hiperhealth/pipeline/registry.py
@@ -309,8 +309,13 @@ class SkillRegistry:
         """
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp) / 'repo'
+            git_path = shutil.which('git')
+            if not git_path:
+                msg = 'git executable not found in PATH'
+                raise RuntimeError(msg)
+
             subprocess.run(
-                ['git', 'clone', '--depth', '1', url, str(tmp_path)],
+                [git_path, 'clone', '--depth', '1', url, str(tmp_path)],
                 check=True,
                 capture_output=True,
             )
@@ -323,7 +328,7 @@ class SkillRegistry:
           deps:
             type: list[str]
         """
-        subprocess.run(
+        subprocess.run(  # nosec B603
             [sys.executable, '-m', 'pip', 'install', *deps],
             check=True,
             capture_output=True,

--- a/src/hiperhealth/security/__init__.py
+++ b/src/hiperhealth/security/__init__.py
@@ -1,0 +1,34 @@
+"""
+title: Security & access-control primitives for hiperhealth.
+summary: |-
+  Re-exports from sub-modules for convenient top-level imports::
+
+      from hiperhealth.security import SecurityContext, check_authenticated
+"""
+
+from hiperhealth.security.context import Role, SecurityContext
+from hiperhealth.security.exceptions import (
+    AuthenticationError,
+    AuthorizationError,
+    PatientAccessDeniedError,
+    SecurityError,
+)
+from hiperhealth.security.guards import (
+    check_authenticated,
+    check_patient_access,
+    check_permission,
+    check_role,
+)
+
+__all__ = [
+    'AuthenticationError',
+    'AuthorizationError',
+    'PatientAccessDeniedError',
+    'Role',
+    'SecurityContext',
+    'SecurityError',
+    'check_authenticated',
+    'check_patient_access',
+    'check_permission',
+    'check_role',
+]

--- a/src/hiperhealth/security/context.py
+++ b/src/hiperhealth/security/context.py
@@ -1,0 +1,83 @@
+"""
+title: Security context model for hiperhealth.
+summary: |-
+  Provides a ``SecurityContext`` that callers attach to library
+  operations so that identity, role, and permissions can be verified
+  before processing sensitive healthcare data.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class Role(str, Enum):
+    """
+    title: Supported user roles.
+    """
+
+    PHYSICIAN = 'physician'
+    RESEARCHER = 'researcher'
+    ADMIN = 'admin'
+    PATIENT = 'patient'
+
+
+class SecurityContext(BaseModel):
+    """
+    title: Immutable security context attached to every protected call.
+    attributes:
+      user_id:
+        type: str
+        description: Authenticated caller identity.
+      role:
+        type: Role
+        description: Caller role.
+      patient_id:
+        type: str | None
+        description: >-
+          The patient being accessed.  Required for patient-scoped operations.
+      session_id:
+        type: str | None
+        description: Optional trace / session correlation id.
+      permissions:
+        type: frozenset[str]
+        description: >-
+          Fine-grained permission strings, e.g. ``read:reports``,
+          ``write:diagnosis``.
+    """
+
+    user_id: str
+    role: Role
+    patient_id: str | None = None
+    session_id: str | None = None
+    permissions: frozenset[str] = Field(default_factory=frozenset)
+
+    model_config = ConfigDict(frozen=True)
+
+    def has_permission(self, permission: str) -> bool:
+        """
+        title: Check whether this context grants a specific permission.
+        parameters:
+          permission:
+            type: str
+            description: Value for permission.
+        returns:
+          type: bool
+          description: Return value.
+        """
+        return permission in self.permissions
+
+    def has_role(self, role: Role) -> bool:
+        """
+        title: Check whether this context matches a required role.
+        parameters:
+          role:
+            type: Role
+            description: Value for role.
+        returns:
+          type: bool
+          description: Return value.
+        """
+        return self.role == role

--- a/src/hiperhealth/security/exceptions.py
+++ b/src/hiperhealth/security/exceptions.py
@@ -1,0 +1,54 @@
+"""
+title: Security exception hierarchy for hiperhealth.
+"""
+
+from __future__ import annotations
+
+
+class SecurityError(Exception):
+    """
+    title: Base class for all security-related errors.
+    """
+
+    ...
+
+
+class AuthenticationError(SecurityError):
+    """
+    title: Raised when no valid security context is provided.
+    summary: |-
+      This error indicates that a caller attempted to use a protected
+      function without providing a valid ``SecurityContext``.
+    """
+
+    def __init__(self, message: str = 'Authentication required') -> None:
+        super().__init__(message)
+
+
+class AuthorizationError(SecurityError):
+    """
+    title: Raised when the caller lacks a required role or permission.
+    """
+
+    def __init__(self, message: str = 'Insufficient permissions') -> None:
+        super().__init__(message)
+
+
+class PatientAccessDeniedError(AuthorizationError):
+    """
+    title: Raised when the caller is not authorized for the given patient.
+    """
+
+    def __init__(
+        self,
+        *,
+        user_id: str = '',
+        patient_id: str = '',
+    ) -> None:
+        detail = (
+            f'User {user_id!r} is not authorized to access '
+            f'patient {patient_id!r}'
+            if user_id and patient_id
+            else 'Patient access denied'
+        )
+        super().__init__(detail)

--- a/src/hiperhealth/security/guards.py
+++ b/src/hiperhealth/security/guards.py
@@ -1,0 +1,111 @@
+"""
+title: Guard functions for verifying security context.
+summary: |-
+  Provides explicit guard functions that skills call at the top of
+  protected methods.  Enforcement is controlled by the
+  ``HIPERHEALTH_REQUIRE_AUTH`` environment variable (default ``false``).
+"""
+
+from __future__ import annotations
+
+import os
+
+from hiperhealth.security.context import Role, SecurityContext
+from hiperhealth.security.exceptions import (
+    AuthenticationError,
+    AuthorizationError,
+    PatientAccessDeniedError,
+)
+
+
+def _is_enforcement_enabled() -> bool:
+    """
+    title: Return True when mandatory auth enforcement is turned on.
+    returns:
+      type: bool
+      description: Return value.
+    """
+    return os.getenv('HIPERHEALTH_REQUIRE_AUTH', 'false').lower() in (
+        '1',
+        'true',
+        'yes',
+    )
+
+
+def check_authenticated(ctx: SecurityContext | None) -> None:
+    """
+    title: Verify a non-None security context is present.
+    summary: |-
+      When enforcement is disabled (default) and *ctx* is ``None``,
+      the call is silently allowed for backward compatibility.
+    parameters:
+      ctx:
+        type: SecurityContext | None
+        description: Value for ctx.
+    """
+    if ctx is None and _is_enforcement_enabled():
+        raise AuthenticationError(
+            'A SecurityContext is required when '
+            'HIPERHEALTH_REQUIRE_AUTH is enabled'
+        )
+
+
+def check_role(ctx: SecurityContext | None, required_role: Role) -> None:
+    """
+    title: Verify the context's role matches the required role.
+    parameters:
+      ctx:
+        type: SecurityContext | None
+        description: Value for ctx.
+      required_role:
+        type: Role
+        description: Value for required_role.
+    """
+    if ctx is None:
+        return
+    if not ctx.has_role(required_role):
+        raise AuthorizationError(
+            f'Role {required_role.value!r} required, got {ctx.role.value!r}'
+        )
+
+
+def check_permission(ctx: SecurityContext | None, permission: str) -> None:
+    """
+    title: Verify the context grants a specific permission.
+    parameters:
+      ctx:
+        type: SecurityContext | None
+        description: Value for ctx.
+      permission:
+        type: str
+        description: Value for permission.
+    """
+    if ctx is None:
+        return
+    if not ctx.has_permission(permission):
+        raise AuthorizationError(f'Permission {permission!r} required')
+
+
+def check_patient_access(ctx: SecurityContext | None, patient_id: str) -> None:
+    """
+    title: Verify the caller is authorized for a specific patient.
+    summary: |-
+      Admins bypass this check.  For other roles the context's
+      ``patient_id`` must match the requested *patient_id*.
+    parameters:
+      ctx:
+        type: SecurityContext | None
+        description: Value for ctx.
+      patient_id:
+        type: str
+        description: Value for patient_id.
+    """
+    if ctx is None:
+        return
+    # Admins can access any patient.
+    if ctx.role == Role.ADMIN:
+        return
+    if ctx.patient_id != patient_id:
+        raise PatientAccessDeniedError(
+            user_id=ctx.user_id, patient_id=patient_id
+        )

--- a/src/hiperhealth/skills/diagnostics/core.py
+++ b/src/hiperhealth/skills/diagnostics/core.py
@@ -14,6 +14,8 @@ from hiperhealth.pipeline.context import PipelineContext
 from hiperhealth.pipeline.skill import BaseSkill, SkillMetadata
 from hiperhealth.pipeline.stages import Stage
 from hiperhealth.schema.clinical_outputs import LLMDiagnosis
+from hiperhealth.security.context import SecurityContext
+from hiperhealth.security.guards import check_authenticated, check_permission
 
 _DIAG_PROMPTS = {
     'en': (
@@ -85,6 +87,7 @@ def differential(
     session_id: str | None = None,
     llm: StructuredLLM | None = None,
     llm_settings: LLMSettings | None = None,
+    security_context: SecurityContext | None = None,
 ) -> LLMDiagnosis:
     """
     title: Return summary + list of differential diagnoses.
@@ -104,10 +107,15 @@ def differential(
       llm_settings:
         type: LLMSettings | None
         description: Value for llm_settings.
+      security_context:
+        type: SecurityContext | None
+        description: Optional security context for access control.
     returns:
       type: LLMDiagnosis
       description: Return value.
     """
+    check_authenticated(security_context)
+    check_permission(security_context, 'read:diagnosis')
     prompt = _DIAG_PROMPTS.get(language, _DIAG_PROMPTS['en'])
     chat_kwargs: dict[str, Any] = {'session_id': session_id}
     if llm is not None:
@@ -127,6 +135,7 @@ def exams(
     session_id: str | None = None,
     llm: StructuredLLM | None = None,
     llm_settings: LLMSettings | None = None,
+    security_context: SecurityContext | None = None,
 ) -> LLMDiagnosis:
     """
     title: Return summary + list of suggested examinations.
@@ -146,10 +155,15 @@ def exams(
       llm_settings:
         type: LLMSettings | None
         description: Value for llm_settings.
+      security_context:
+        type: SecurityContext | None
+        description: Optional security context for access control.
     returns:
       type: LLMDiagnosis
       description: Return value.
     """
+    check_authenticated(security_context)
+    check_permission(security_context, 'read:diagnosis')
     prompt = _EXAM_PROMPTS.get(language, _EXAM_PROMPTS['en'])
     chat_kwargs: dict[str, Any] = {'session_id': session_id}
     if llm is not None:

--- a/src/hiperhealth/skills/extraction/medical_reports.py
+++ b/src/hiperhealth/skills/extraction/medical_reports.py
@@ -25,6 +25,9 @@ from PIL import Image
 from pypdf import PdfReader
 from pypdf.errors import EmptyFileError, PdfStreamError
 
+from hiperhealth.security.context import SecurityContext
+from hiperhealth.security.guards import check_authenticated, check_permission
+
 
 class MedicalReportExtractorError(Exception):
     """
@@ -130,6 +133,7 @@ class MedicalReportFileExtractor(BaseMedicalReportExtractor[FileInput]):
     def extract_report_data(
         self,
         source: FileInput,
+        security_context: SecurityContext | None = None,
     ) -> dict[str, Any]:
         """
         title: Validate input and return extracted text plus basic metadata.
@@ -137,10 +141,15 @@ class MedicalReportFileExtractor(BaseMedicalReportExtractor[FileInput]):
           source:
             type: FileInput
             description: Value for source.
+          security_context:
+            type: SecurityContext | None
+            description: Optional security context for access control.
         returns:
           type: dict[str, Any]
           description: Return value.
         """
+        check_authenticated(security_context)
+        check_permission(security_context, 'read:reports')
         self._validate_or_raise(source)
         return self._process_file(source)
 
@@ -249,17 +258,26 @@ class MedicalReportFileExtractor(BaseMedicalReportExtractor[FileInput]):
         self._text_cache[key] = text
         return text
 
-    def extract_text(self, source: FileInput) -> str:
+    def extract_text(
+        self,
+        source: FileInput,
+        security_context: SecurityContext | None = None,
+    ) -> str:
         """
         title: Validate input and return the extracted raw text only.
         parameters:
           source:
             type: FileInput
             description: Value for source.
+          security_context:
+            type: SecurityContext | None
+            description: Optional security context for access control.
         returns:
           type: str
           description: Return value.
         """
+        check_authenticated(security_context)
+        check_permission(security_context, 'read:reports')
         self._validate_or_raise(source)
         return self._extract_text(source)
 

--- a/src/hiperhealth/skills/extraction/wearable.py
+++ b/src/hiperhealth/skills/extraction/wearable.py
@@ -15,6 +15,8 @@ from typing import IO, Any, ClassVar, Generic, Literal, TypeVar, cast
 
 import magic
 
+from hiperhealth.security.context import SecurityContext
+from hiperhealth.security.guards import check_authenticated, check_permission
 from hiperhealth.utils import is_float
 
 
@@ -114,7 +116,9 @@ class WearableDataFileExtractor(BaseWearableDataExtractor[FileInput]):
         ]
 
     def extract_wearable_data(
-        self, file: FileInput
+        self,
+        file: FileInput,
+        security_context: SecurityContext | None = None,
     ) -> list[dict[str, object]]:
         """
         title: Extract wearable data from file.
@@ -122,10 +126,15 @@ class WearableDataFileExtractor(BaseWearableDataExtractor[FileInput]):
           file:
             type: FileInput
             description: Value for file.
+          security_context:
+            type: SecurityContext | None
+            description: Optional security context for access control.
         returns:
           type: list[dict[str, object]]
           description: Return value.
         """
+        check_authenticated(security_context)
+        check_permission(security_context, 'read:wearables')
         self._validate_or_raise(file)
         return self._process_file(file)
 

--- a/src/hiperhealth/skills/privacy/deidentifier.py
+++ b/src/hiperhealth/skills/privacy/deidentifier.py
@@ -4,7 +4,7 @@ title: PII detection, de-identification, and PrivacySkill.
 
 import logging
 
-from typing import Optional
+from typing import Optional, cast
 
 from presidio_analyzer import (
     AnalyzerEngine,
@@ -18,6 +18,8 @@ from presidio_anonymizer.entities import OperatorConfig
 from hiperhealth.pipeline.context import PipelineContext
 from hiperhealth.pipeline.skill import BaseSkill, SkillMetadata
 from hiperhealth.pipeline.stages import Stage
+from hiperhealth.security.context import SecurityContext
+from hiperhealth.security.guards import check_authenticated, check_permission
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +39,7 @@ class Deidentifier:
         title: Initialize the Presidio Analyzer and Anonymizer engines.
         """
         self.analyzer = AnalyzerEngine()
-        self.anonymizer = AnonymizerEngine()  # type: ignore[no-untyped-call]
+        self.anonymizer = AnonymizerEngine()
 
     def add_custom_recognizer(
         self,
@@ -127,12 +129,19 @@ class Deidentifier:
           type: list[RecognizerResult]
           description: Return value.
         """
-        return self.analyzer.analyze(
-            text=text, entities=entities, language=language
+        return cast(
+            list[RecognizerResult],
+            self.analyzer.analyze(
+                text=text, entities=entities, language=language
+            ),
         )
 
     def deidentify(
-        self, text: str, strategy: str = 'mask', language: str = 'en'
+        self,
+        text: str,
+        strategy: str = 'mask',
+        language: str = 'en',
+        security_context: SecurityContext | None = None,
     ) -> str:
         """
         title: Anonymize detected PII in the text using a specified strategy.
@@ -146,10 +155,15 @@ class Deidentifier:
           language:
             type: str
             description: Value for language.
+          security_context:
+            type: SecurityContext | None
+            description: Optional security context for access control.
         returns:
           type: str
           description: Return value.
         """
+        check_authenticated(security_context)
+        check_permission(security_context, 'write:deidentify')
         # First, ensure the provided strategy is supported.
         supported_strategies = ['mask', 'hash']
         if strategy not in supported_strategies:
@@ -187,10 +201,10 @@ class Deidentifier:
 
         anonymized_result = self.anonymizer.anonymize(
             text=text,
-            analyzer_results=analyzer_results,  # type: ignore[arg-type]
+            analyzer_results=analyzer_results,
             operators=operators.get(strategy),
         )
-        return anonymized_result.text
+        return cast(str, anonymized_result.text)
 
 
 _DEFAULT_KEYS_TO_DEIDENTIFY = frozenset(
@@ -210,6 +224,7 @@ def deidentify_patient_record(
     record: dict[str, object],
     deidentifier: Deidentifier,
     keys_to_deidentify: frozenset[str] | None = None,
+    security_context: SecurityContext | None = None,
 ) -> dict[str, object]:
     """
     title: Recursively find and de-identify string values in a patient record.
@@ -227,10 +242,15 @@ def deidentify_patient_record(
       keys_to_deidentify:
         type: frozenset[str] | None
         description: Value for keys_to_deidentify.
+      security_context:
+        type: SecurityContext | None
+        description: Optional security context for access control.
     returns:
       type: dict[str, object]
       description: Return value.
     """
+    check_authenticated(security_context)
+    check_permission(security_context, 'write:deidentify')
     effective_keys = (
         keys_to_deidentify
         if keys_to_deidentify is not None

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,187 @@
+"""
+title: Unit tests for the hiperhealth.security module.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hiperhealth.security.context import Role, SecurityContext
+from hiperhealth.security.exceptions import (
+    AuthenticationError,
+    AuthorizationError,
+    PatientAccessDeniedError,
+    SecurityError,
+)
+from hiperhealth.security.guards import (
+    check_authenticated,
+    check_patient_access,
+    check_permission,
+    check_role,
+)
+
+# ── SecurityContext ──────────────────────────────────────────────────
+
+
+class TestSecurityContext:
+    def test_create_minimal(self) -> None:
+        ctx = SecurityContext(user_id='u1', role=Role.PHYSICIAN)
+        assert ctx.user_id == 'u1'
+        assert ctx.role == Role.PHYSICIAN
+        assert ctx.patient_id is None
+        assert ctx.permissions == frozenset()
+
+    def test_create_full(self) -> None:
+        ctx = SecurityContext(
+            user_id='u2',
+            role=Role.ADMIN,
+            patient_id='p1',
+            session_id='s1',
+            permissions=frozenset({'read:reports', 'write:deidentify'}),
+        )
+        assert ctx.patient_id == 'p1'
+        assert ctx.session_id == 's1'
+        assert ctx.has_permission('read:reports')
+        assert not ctx.has_permission('delete:all')
+
+    def test_has_role(self) -> None:
+        ctx = SecurityContext(user_id='u1', role=Role.RESEARCHER)
+        assert ctx.has_role(Role.RESEARCHER)
+        assert not ctx.has_role(Role.ADMIN)
+
+    def test_role_enum_values(self) -> None:
+        assert Role.PHYSICIAN.value == 'physician'
+        assert Role.RESEARCHER.value == 'researcher'
+        assert Role.ADMIN.value == 'admin'
+        assert Role.PATIENT.value == 'patient'
+
+
+# ── Exception Hierarchy ──────────────────────────────────────────────
+
+
+class TestExceptions:
+    def test_authentication_error_is_security_error(self) -> None:
+        assert issubclass(AuthenticationError, SecurityError)
+
+    def test_authorization_error_is_security_error(self) -> None:
+        assert issubclass(AuthorizationError, SecurityError)
+
+    def test_patient_access_denied_is_authorization_error(self) -> None:
+        assert issubclass(PatientAccessDeniedError, AuthorizationError)
+
+    def test_authentication_error_default_message(self) -> None:
+        err = AuthenticationError()
+        assert 'Authentication required' in str(err)
+
+    def test_authorization_error_default_message(self) -> None:
+        err = AuthorizationError()
+        assert 'Insufficient permissions' in str(err)
+
+    def test_patient_access_denied_with_details(self) -> None:
+        err = PatientAccessDeniedError(user_id='u1', patient_id='p1')
+        assert 'u1' in str(err)
+        assert 'p1' in str(err)
+
+    def test_patient_access_denied_without_details(self) -> None:
+        err = PatientAccessDeniedError()
+        assert 'Patient access denied' in str(err)
+
+
+# ── Guard Functions ──────────────────────────────────────────────────
+
+
+class TestCheckAuthenticated:
+    def test_none_without_enforcement_passes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv('HIPERHEALTH_REQUIRE_AUTH', raising=False)
+        check_authenticated(None)  # should not raise
+
+    def test_none_with_enforcement_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv('HIPERHEALTH_REQUIRE_AUTH', 'true')
+        with pytest.raises(AuthenticationError):
+            check_authenticated(None)
+
+    def test_valid_context_with_enforcement_passes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv('HIPERHEALTH_REQUIRE_AUTH', 'true')
+        ctx = SecurityContext(user_id='u1', role=Role.PHYSICIAN)
+        check_authenticated(ctx)  # should not raise
+
+    @pytest.mark.parametrize('value', ['1', 'True', 'YES', 'true'])
+    def test_enforcement_truthy_values(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ) -> None:
+        monkeypatch.setenv('HIPERHEALTH_REQUIRE_AUTH', value)
+        with pytest.raises(AuthenticationError):
+            check_authenticated(None)
+
+    @pytest.mark.parametrize('value', ['0', 'false', 'no', ''])
+    def test_enforcement_falsy_values(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ) -> None:
+        monkeypatch.setenv('HIPERHEALTH_REQUIRE_AUTH', value)
+        check_authenticated(None)  # should not raise
+
+
+class TestCheckRole:
+    def test_none_context_passes(self) -> None:
+        check_role(None, Role.PHYSICIAN)  # should not raise
+
+    def test_matching_role_passes(self) -> None:
+        ctx = SecurityContext(user_id='u1', role=Role.PHYSICIAN)
+        check_role(ctx, Role.PHYSICIAN)  # should not raise
+
+    def test_wrong_role_raises(self) -> None:
+        ctx = SecurityContext(user_id='u1', role=Role.PATIENT)
+        with pytest.raises(AuthorizationError, match='physician'):
+            check_role(ctx, Role.PHYSICIAN)
+
+
+class TestCheckPermission:
+    def test_none_context_passes(self) -> None:
+        check_permission(None, 'read:reports')  # should not raise
+
+    def test_has_permission_passes(self) -> None:
+        ctx = SecurityContext(
+            user_id='u1',
+            role=Role.PHYSICIAN,
+            permissions=frozenset({'read:reports'}),
+        )
+        check_permission(ctx, 'read:reports')  # should not raise
+
+    def test_missing_permission_raises(self) -> None:
+        ctx = SecurityContext(
+            user_id='u1',
+            role=Role.PHYSICIAN,
+            permissions=frozenset({'read:reports'}),
+        )
+        with pytest.raises(AuthorizationError, match='write:deidentify'):
+            check_permission(ctx, 'write:deidentify')
+
+
+class TestCheckPatientAccess:
+    def test_none_context_passes(self) -> None:
+        check_patient_access(None, 'p1')  # should not raise
+
+    def test_admin_bypasses_check(self) -> None:
+        ctx = SecurityContext(
+            user_id='u1', role=Role.ADMIN, patient_id='p_other'
+        )
+        check_patient_access(ctx, 'p1')  # admin can access any patient
+
+    def test_matching_patient_passes(self) -> None:
+        ctx = SecurityContext(
+            user_id='u1', role=Role.PHYSICIAN, patient_id='p1'
+        )
+        check_patient_access(ctx, 'p1')  # should not raise
+
+    def test_wrong_patient_raises(self) -> None:
+        ctx = SecurityContext(
+            user_id='u1', role=Role.PHYSICIAN, patient_id='p2'
+        )
+        with pytest.raises(PatientAccessDeniedError):
+            check_patient_access(ctx, 'p1')

--- a/tests/test_security_integration.py
+++ b/tests/test_security_integration.py
@@ -1,0 +1,207 @@
+"""
+title: Integration tests verifying security guards at skill entry points.
+summary: |-
+  These tests check that when ``HIPERHEALTH_REQUIRE_AUTH=true`` the
+  core skill functions reject unauthenticated callers, and that
+  correct contexts are accepted.
+"""
+
+from __future__ import annotations
+
+import io
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from hiperhealth.security.context import Role, SecurityContext
+from hiperhealth.security.exceptions import (
+    AuthenticationError,
+    AuthorizationError,
+)
+
+
+def _physician_ctx(
+    *,
+    permissions: frozenset[str] = frozenset(),
+) -> SecurityContext:
+    return SecurityContext(
+        user_id='dr-test',
+        role=Role.PHYSICIAN,
+        patient_id='patient-1',
+        permissions=permissions,
+    )
+
+
+# ── MedicalReportFileExtractor ────────────────────────────────────
+
+
+class TestMedicalReportExtractorSecurity:
+    def test_extract_report_data_rejects_no_ctx_when_enforced(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv('HIPERHEALTH_REQUIRE_AUTH', 'true')
+        from hiperhealth.skills.extraction.medical_reports import (
+            MedicalReportFileExtractor,
+        )
+
+        extractor = MedicalReportFileExtractor()
+        with pytest.raises(AuthenticationError):
+            extractor.extract_report_data(io.BytesIO(b'dummy'))
+
+    def test_extract_report_data_rejects_wrong_permission(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv('HIPERHEALTH_REQUIRE_AUTH', raising=False)
+        from hiperhealth.skills.extraction.medical_reports import (
+            MedicalReportFileExtractor,
+        )
+
+        ctx = _physician_ctx(permissions=frozenset({'write:deidentify'}))
+        extractor = MedicalReportFileExtractor()
+        with pytest.raises(AuthorizationError, match='read:reports'):
+            extractor.extract_report_data(
+                io.BytesIO(b'dummy'), security_context=ctx
+            )
+
+    def test_extract_text_rejects_no_ctx_when_enforced(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv('HIPERHEALTH_REQUIRE_AUTH', 'true')
+        from hiperhealth.skills.extraction.medical_reports import (
+            MedicalReportFileExtractor,
+        )
+
+        extractor = MedicalReportFileExtractor()
+        with pytest.raises(AuthenticationError):
+            extractor.extract_text(io.BytesIO(b'dummy'))
+
+
+# ── WearableDataFileExtractor ────────────────────────────────────
+
+
+class TestWearableDataExtractorSecurity:
+    def test_rejects_no_ctx_when_enforced(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv('HIPERHEALTH_REQUIRE_AUTH', 'true')
+        from hiperhealth.skills.extraction.wearable import (
+            WearableDataFileExtractor,
+        )
+
+        extractor = WearableDataFileExtractor()
+        with pytest.raises(AuthenticationError):
+            extractor.extract_wearable_data(io.BytesIO(b'{}'))
+
+    def test_rejects_wrong_permission(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv('HIPERHEALTH_REQUIRE_AUTH', raising=False)
+        from hiperhealth.skills.extraction.wearable import (
+            WearableDataFileExtractor,
+        )
+
+        ctx = _physician_ctx(permissions=frozenset({'read:reports'}))
+        extractor = WearableDataFileExtractor()
+        with pytest.raises(AuthorizationError, match='read:wearables'):
+            extractor.extract_wearable_data(
+                io.BytesIO(b'{}'), security_context=ctx
+            )
+
+
+# ── Deidentifier ─────────────────────────────────────────────────
+
+
+class TestDeidentifierSecurity:
+    def test_deidentify_rejects_no_ctx_when_enforced(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv('HIPERHEALTH_REQUIRE_AUTH', 'true')
+
+        import hiperhealth.skills.privacy.deidentifier as deid_mod
+
+        # Patch out heavy Presidio engines
+        monkeypatch.setattr(deid_mod, 'AnalyzerEngine', lambda: MagicMock())
+        monkeypatch.setattr(deid_mod, 'AnonymizerEngine', lambda: MagicMock())
+
+        deid = deid_mod.Deidentifier()
+        with pytest.raises(AuthenticationError):
+            deid.deidentify('some text')
+
+    def test_deidentify_patient_record_rejects_no_ctx(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv('HIPERHEALTH_REQUIRE_AUTH', 'true')
+
+        import hiperhealth.skills.privacy.deidentifier as deid_mod
+
+        monkeypatch.setattr(deid_mod, 'AnalyzerEngine', lambda: MagicMock())
+        monkeypatch.setattr(deid_mod, 'AnonymizerEngine', lambda: MagicMock())
+
+        deid = deid_mod.Deidentifier()
+        with pytest.raises(AuthenticationError):
+            deid_mod.deidentify_patient_record({'symptoms': 'test'}, deid)
+
+
+# ── Diagnostics ──────────────────────────────────────────────────
+
+
+class TestDiagnosticsSecurity:
+    def test_differential_rejects_no_ctx_when_enforced(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv('HIPERHEALTH_REQUIRE_AUTH', 'true')
+        from hiperhealth.skills.diagnostics.core import differential
+
+        with pytest.raises(AuthenticationError):
+            differential({'age': 30})
+
+    def test_exams_rejects_no_ctx_when_enforced(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv('HIPERHEALTH_REQUIRE_AUTH', 'true')
+        from hiperhealth.skills.diagnostics.core import exams
+
+        with pytest.raises(AuthenticationError):
+            exams(['flu'])
+
+    def test_differential_rejects_wrong_permission(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv('HIPERHEALTH_REQUIRE_AUTH', raising=False)
+        from hiperhealth.skills.diagnostics.core import differential
+
+        ctx = _physician_ctx(permissions=frozenset({'write:deidentify'}))
+        with pytest.raises(AuthorizationError, match='read:diagnosis'):
+            differential({'age': 30}, security_context=ctx)
+
+
+# ── Default Mode (enforcement off) ──────────────────────────────
+
+
+class TestDefaultModeAllowsNoContext:
+    def test_medical_report_no_ctx_allowed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv('HIPERHEALTH_REQUIRE_AUTH', raising=False)
+        from hiperhealth.skills.extraction.medical_reports import (
+            MedicalReportFileExtractor,
+        )
+
+        extractor = MedicalReportFileExtractor()
+        # Will fail at file validation (not auth) — that's expected
+        with pytest.raises(FileNotFoundError):
+            extractor.extract_report_data(io.BytesIO(b''))
+
+    def test_wearable_no_ctx_allowed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv('HIPERHEALTH_REQUIRE_AUTH', raising=False)
+        from hiperhealth.skills.extraction.wearable import (
+            WearableDataFileExtractor,
+        )
+
+        extractor = WearableDataFileExtractor()
+        # Will fail at validation (not auth)
+        with pytest.raises(Exception):
+            extractor.extract_wearable_data(io.BytesIO(b''))


### PR DESCRIPTION

@xmnlab
I completely agree that the application should own the security policy.

I implemented this opt-in layer only as a standardised SecurityContext that could travel alongside the PipelineContext. Since Hiperhealth deals with sensitive PHI, it allows skills to adjust their behaviour based on the caller's role without re-implementing logic every time.

That was my reasoning, but if you'd prefer to keep it out of the core library, I am happy to remove it!"