### PR TITLE
fix: support string file paths in wearable extraction API

### DIFF
--- a/src/hiperhealth/skills/extraction/wearable.py
+++ b/src/hiperhealth/skills/extraction/wearable.py
@@ -129,6 +129,19 @@ class WearableDataFileExtractor(BaseWearableDataExtractor[FileInput]):
         self._validate_or_raise(file)
         return self._process_file(file)
 
+    def _normalize_file_input(self, file: FileInput) -> FileInput:
+        """
+        title: Normalize file path inputs to Path instances.
+        parameters:
+          file:
+            type: FileInput
+        returns:
+          type: FileInput
+        """
+        if isinstance(file, str):
+            return Path(file)
+        return file
+
     def _process_file(self, file: FileInput) -> list[dict[str, object]]:
         """
         title: Dispatch file processing based on detected file format.
@@ -159,6 +172,8 @@ class WearableDataFileExtractor(BaseWearableDataExtractor[FileInput]):
           type: bool
           description: Return value.
         """
+        file = self._normalize_file_input(file)
+
         if isinstance(file, (tempfile.SpooledTemporaryFile, io.BytesIO)):
             # if it's a inmemory-temp file, validate it
             return self._validate_inmemory_file(file)
@@ -211,6 +226,7 @@ class WearableDataFileExtractor(BaseWearableDataExtractor[FileInput]):
           type: str
           description: Return value.
         """
+        file = self._normalize_file_input(file)
         cache_key = self._get_cache_key(file)
 
         if cache_key in self._mimetype_cache:
@@ -243,6 +259,7 @@ class WearableDataFileExtractor(BaseWearableDataExtractor[FileInput]):
         returns:
           type: str
         """
+        file = self._normalize_file_input(file)
         cache_key: str
         if isinstance(file, Path):
             cache_key = str(file.resolve())

--- a/tests/test_extraction_wearable.py
+++ b/tests/test_extraction_wearable.py
@@ -56,6 +56,23 @@ def test_extract_csv(wearable_extractor):
     assert len(wearable_data) > 0
 
 
+def test_extract_csv_from_string_path(wearable_extractor):
+    """
+    title: Test that CSV string paths can be extracted.
+    parameters:
+      wearable_extractor:
+        description: Value for wearable_extractor.
+    """
+    csv_path = str(CSV_FILE)
+
+    assert wearable_extractor.is_supported(csv_path)
+    assert wearable_extractor._is_csv(csv_path)
+    wearable_data = wearable_extractor.extract_wearable_data(csv_path)
+
+    assert wearable_data
+    assert len(wearable_data) > 0
+
+
 def test_extract_unsupported_file(wearable_extractor):
     """
     title: Test that unsupported file cannot be extracted.


### PR DESCRIPTION


## Pull Request description

Fixes #215

Handles string file paths in wearable extraction by normalizing `str` inputs to `Path` before validation, MIME detection, and cache key generation.

Adds a regression test to ensure string paths work as expected.


## How to test these changes

```bash
pytest tests/test_extraction_wearable.py -k string_path
```

Or manually:

```python
from hiperhealth.skills.extraction.wearable import extract_wearable_data

extract_wearable_data("tests/data/wearable/wearable_data.csv")
```

## Pull Request checklists

This PR is a:

* [x] bug-fix
* [ ] new feature
* [ ] maintenance

About this PR:

* [x] it includes tests
* [x] the tests are executed on CI
* [ ] the tests generate log file(s)
* [ ] pre-commit hooks were executed locally
* [ ] this PR requires a project documentation update

Author's checklist:

* [x] I have reviewed the changes
* [x] Code is minimal and focused
* [x] Tests pass locally


## Additional information

This fixes the mismatch between the documented API (`str` supported) and internal handling (only `Path` supported), without changing existing behavior.
