### PR TITLE
refactor: replace Optional[X] with X | None syntax (closes #187)

### DIFF
--- a/src/hiperhealth/schema/human_evaluations.py
+++ b/src/hiperhealth/schema/human_evaluations.py
@@ -5,7 +5,7 @@ title: Domain-specific (non-FHIR) Pydantic models used across the platform.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Literal, Optional
+from typing import Literal
 
 from pydantic import BaseModel
 
@@ -64,7 +64,7 @@ class Evaluation(BaseLanguage, BaseModel):
         type: Literal[safe, needs_review, unsafe]
         description: Value for safety.
       comments:
-        type: Optional[str]
+        type: str | None
         description: Value for comments.
       timestamp:
         type: datetime
@@ -78,7 +78,7 @@ class Evaluation(BaseLanguage, BaseModel):
         Literal['accuracy', 'relevance', 'usefulness', 'coherence'], int
     ]
     safety: Literal['safe', 'needs_review', 'unsafe']
-    comments: Optional[str] = None
+    comments: str | None = None
     timestamp: datetime
 
 
@@ -102,7 +102,7 @@ class DeIdentifiedDatasetDescriptor(BaseLanguage, BaseModel):
         type: str
         description: Value for license.
       url:
-        type: Optional[str]
+        type: str | None
         description: Value for url.
     """
 
@@ -111,4 +111,4 @@ class DeIdentifiedDatasetDescriptor(BaseLanguage, BaseModel):
     version: str
     records: int
     license: str
-    url: Optional[str] = None
+    url: str | None = None

--- a/src/hiperhealth/skills/privacy/deidentifier.py
+++ b/src/hiperhealth/skills/privacy/deidentifier.py
@@ -2,9 +2,9 @@
 title: PII detection, de-identification, and PrivacySkill.
 """
 
-import logging
+from __future__ import annotations
 
-from typing import Optional
+import logging
 
 from presidio_analyzer import (
     AnalyzerEngine,
@@ -108,7 +108,7 @@ class Deidentifier:
     def analyze(
         self,
         text: str,
-        entities: Optional[list[str]] = None,
+        entities: list[str] | None = None,
         language: str = 'en',
     ) -> list[RecognizerResult]:
         """
@@ -118,7 +118,7 @@ class Deidentifier:
             type: str
             description: Value for text.
           entities:
-            type: Optional[list[str]]
+            type: list[str] | None
             description: Value for entities.
           language:
             type: str


### PR DESCRIPTION
## What

Replaces `typing.Optional[X]` with the modern `X | None` union syntax
(PEP 604) in two files:

- `src/hiperhealth/skills/privacy/deidentifier.py`
- `src/hiperhealth/schema/human_evaluations.py`

Also adds `from __future__ import annotations` to `deidentifier.py`
to enable PEP 563 postponed evaluation, consistent with the rest of
the codebase.

## Why

`typing.Optional` is a Pydantic v1 / Python 3.9 pattern. The project
targets Python ≥ 3.10 and already uses `X | None` syntax everywhere
else. The `from __future__ import annotations` import was missing from
`deidentifier.py`, making it the only file in `src/` without it.

## Testing

- `ruff check` and `ruff format --check` pass on both files
- `douki sync` reports no changes
- No logic changes — purely a typing annotation update

Closes #187