### PR TITLE
fix(llm): retry transient LiteLLM errors with exponential backoff (cl…

### DIFF
--- a/src/hiperhealth/llm.py
+++ b/src/hiperhealth/llm.py
@@ -5,12 +5,20 @@ title: Provider-agnostic LLM settings and structured-generation adapters.
 from __future__ import annotations
 
 import json
+import logging
 import os
 
 from dataclasses import dataclass, field, replace
 from typing import Any, Callable, Protocol, TypeVar, cast
 
 from pydantic import BaseModel
+from tenacity import (
+    before_sleep_log,
+    retry,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 TModel = TypeVar('TModel', bound=BaseModel)
 
@@ -40,6 +48,70 @@ _DEFAULT_PROVIDER_MODEL = {
     'ollama': 'llama3.2:1b',
     'openai': 'o4-mini',
 }
+
+_log = logging.getLogger(__name__)
+
+
+def _is_transient_litellm_error(exc: BaseException) -> bool:
+    """
+    title: Return True for transient LiteLLM errors that warrant a retry.
+    summary: |-
+      Checks dynamically to avoid a hard import of litellm at module load
+      time. Returns False if litellm is not importable.
+    parameters:
+      exc:
+        type: BaseException
+        description: The exception to evaluate.
+    returns:
+      type: bool
+      description: True if the error is transient and safe to retry.
+    """
+    try:
+        import litellm
+
+        return isinstance(
+            exc,
+            (
+                litellm.RateLimitError,  # type: ignore[attr-defined]
+                litellm.Timeout,  # type: ignore[attr-defined]
+                litellm.APIConnectionError,  # type: ignore[attr-defined]
+                litellm.ServiceUnavailableError,  # type: ignore[attr-defined]
+            ),
+        )
+    except ImportError:
+        return False
+
+
+@retry(
+    retry=retry_if_exception(_is_transient_litellm_error),
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=10),
+    before_sleep=before_sleep_log(_log, logging.WARNING),
+    reraise=True,
+)
+def _call_completion(
+    completion_fn: _CompletionFn,
+    **kwargs: Any,
+) -> Any:
+    """
+    title: Invoke the LiteLLM completion function with transient-error retry.
+    summary: |-
+      Retries up to 3 times with exponential backoff on rate-limit,
+      timeout, connection, and service-unavailable errors. All other
+      exceptions propagate immediately.
+    parameters:
+      completion_fn:
+        type: _CompletionFn
+        description: The LiteLLM completion callable to invoke.
+      kwargs:
+        type: Any
+        description: Keyword arguments forwarded to completion_fn.
+        variadic: keyword
+    returns:
+      type: Any
+      description: The raw LiteLLM response object.
+    """
+    return completion_fn(**kwargs)
 
 
 class StructuredLLM(Protocol):
@@ -287,7 +359,8 @@ class LiteLLMStructuredLLM:
           description: Return value.
         """
         completion_fn = self._get_completion_fn()
-        response = completion_fn(
+        response = _call_completion(
+            completion_fn,
             messages=_build_messages(system, user, output_type),
             **self.settings.to_litellm_kwargs(),
         )

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -11,9 +11,11 @@ import pytest
 from hiperhealth.llm import (
     LiteLLMStructuredLLM,
     LLMSettings,
+    _call_completion,
     _clean_json_text,
     _coerce_model_output,
     _extract_message_content,
+    _is_transient_litellm_error,
     _join_content_blocks,
     _load_api_params,
     build_structured_llm,
@@ -373,3 +375,203 @@ def test_to_litellm_kwargs_always_includes_temperature_and_max_tokens():
         kwargs = settings.to_litellm_kwargs()
         assert kwargs['temperature'] == 0.0
         assert kwargs['max_tokens'] == 4096
+
+
+# ── Transient-error retry tests ────────────────────────────────────
+
+
+class _FakeRateLimitError(Exception):
+    """
+    title: Stand-in for litellm.RateLimitError in retry tests.
+    """
+
+
+class _FakeTimeoutError(Exception):
+    """
+    title: Stand-in for litellm.Timeout in retry tests.
+    """
+
+
+class _FakeAPIConnectionError(Exception):
+    """
+    title: Stand-in for litellm.APIConnectionError in retry tests.
+    """
+
+
+class _FakeServiceUnavailableError(Exception):
+    """
+    title: Stand-in for litellm.ServiceUnavailableError in retry tests.
+    """
+
+
+def test_is_transient_litellm_error_returns_true_for_known_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    title: >-
+      _is_transient_litellm_error returns True for all four LiteLLM error
+      types.
+    parameters:
+      monkeypatch:
+        type: pytest.MonkeyPatch
+        description: Value for monkeypatch.
+    """
+    import types
+
+    fake_litellm = types.ModuleType('litellm')
+    fake_litellm.RateLimitError = _FakeRateLimitError  # type: ignore[attr-defined]
+    fake_litellm.Timeout = _FakeTimeoutError  # type: ignore[attr-defined]
+    fake_litellm.APIConnectionError = _FakeAPIConnectionError  # type: ignore[attr-defined]
+    fake_litellm.ServiceUnavailableError = _FakeServiceUnavailableError  # type: ignore[attr-defined]
+
+    import sys
+
+    monkeypatch.setitem(sys.modules, 'litellm', fake_litellm)
+
+    assert _is_transient_litellm_error(_FakeRateLimitError())
+    assert _is_transient_litellm_error(_FakeTimeoutError())
+    assert _is_transient_litellm_error(_FakeAPIConnectionError())
+    assert _is_transient_litellm_error(_FakeServiceUnavailableError())
+
+
+def test_is_transient_litellm_error_returns_false_for_other_errors() -> None:
+    """
+    title: >-
+      _is_transient_litellm_error returns False for non-transient exceptions.
+    """
+    assert not _is_transient_litellm_error(ValueError('bad input'))
+    assert not _is_transient_litellm_error(TypeError('type mismatch'))
+    assert not _is_transient_litellm_error(RuntimeError('unexpected'))
+
+
+def test_call_completion_retries_on_transient_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    title: _call_completion retries up to 3 times on transient LiteLLM errors.
+    parameters:
+      monkeypatch:
+        type: pytest.MonkeyPatch
+        description: Value for monkeypatch.
+    """
+    import sys
+    import types
+
+    fake_litellm = types.ModuleType('litellm')
+    fake_litellm.RateLimitError = _FakeRateLimitError  # type: ignore[attr-defined]
+    fake_litellm.Timeout = _FakeTimeoutError  # type: ignore[attr-defined]
+    fake_litellm.APIConnectionError = _FakeAPIConnectionError  # type: ignore[attr-defined]
+    fake_litellm.ServiceUnavailableError = _FakeServiceUnavailableError  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, 'litellm', fake_litellm)
+
+    call_count = 0
+    sentinel = object()
+
+    def flaky_completion(**kwargs: object) -> object:
+        """
+        title: Fail with RateLimitError on first two calls, succeed on third.
+        parameters:
+          kwargs:
+            type: object
+            variadic: keyword
+        returns:
+          type: object
+        """
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            raise _FakeRateLimitError('rate limited')
+        return sentinel
+
+    result = _call_completion(flaky_completion)
+    assert result is sentinel
+    assert call_count == 3
+
+
+def test_call_completion_does_not_retry_on_non_transient_error() -> None:
+    """
+    title: >-
+      _call_completion propagates non-transient errors immediately without
+      retry.
+    """
+    call_count = 0
+
+    def always_fails(**kwargs: object) -> object:
+        """
+        title: Always raise a non-transient ValueError.
+        parameters:
+          kwargs:
+            type: object
+            variadic: keyword
+        returns:
+          type: object
+        """
+        nonlocal call_count
+        call_count += 1
+        raise ValueError('bad request')
+
+    with pytest.raises(ValueError, match='bad request'):
+        _call_completion(always_fails)
+
+    assert call_count == 1
+
+
+def test_litellm_structured_llm_retries_on_rate_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    title: >-
+      LiteLLMStructuredLLM.generate retries when completion raises a transient
+      error.
+    parameters:
+      monkeypatch:
+        type: pytest.MonkeyPatch
+        description: Value for monkeypatch.
+    """
+    import sys
+    import types
+
+    from types import SimpleNamespace
+
+    fake_litellm = types.ModuleType('litellm')
+    fake_litellm.RateLimitError = _FakeRateLimitError  # type: ignore[attr-defined]
+    fake_litellm.Timeout = _FakeTimeoutError  # type: ignore[attr-defined]
+    fake_litellm.APIConnectionError = _FakeAPIConnectionError  # type: ignore[attr-defined]
+    fake_litellm.ServiceUnavailableError = _FakeServiceUnavailableError  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, 'litellm', fake_litellm)
+
+    call_count = 0
+    good_response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content='{"summary": "ok", "options": ["A"]}',
+                    parsed=None,
+                    refusal=None,
+                )
+            )
+        ]
+    )
+
+    def completion_fn(**kwargs: object) -> object:
+        """
+        title: Raise RateLimitError on first call, return good response after.
+        parameters:
+          kwargs:
+            type: object
+            variadic: keyword
+        returns:
+          type: object
+        """
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise _FakeRateLimitError('rate limited')
+        return good_response
+
+    settings = LLMSettings(provider='openai', model='o4-mini', api_key='x')
+    llm = LiteLLMStructuredLLM(settings, completion_fn=completion_fn)
+    result = llm.generate('system', 'user', LLMDiagnosis)
+
+    assert call_count == 2
+    assert result.summary == 'ok'


### PR DESCRIPTION
## Pull Request description

Adds retry logic for transient LiteLLM API errors in `LiteLLMStructuredLLM.generate()`.

The raw completion call had no protection against rate limits or timeouts —
a single `RateLimitError` or `Timeout` crashed the request immediately. The
existing tenacity retry in `client.py` only covers parsing failures, not
the API call itself.

Closes #124

## How to test these changes

```bash
pytest tests/test_llm.py -v
```

## Pull Request checklists

This PR is a:

- [x] bug-fix
- [ ] new feature
- [ ] maintenance

About this PR:

- [x] it includes tests.
- [x] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [x] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more complexity.
- [x] New and old tests passed locally.

## Additional information

31/31 tests pass locally (26 pre-existing + 5 new).
ruff, mypy, and douki all clean.

The fix is intentionally minimal — no new dependencies,
no changes to the existing retry in `client.py`.
