### PR TITLE
Add validation to LLMSettings 

### DIFF
--- a/scripts/gen_models/formatting.py
+++ b/scripts/gen_models/formatting.py
@@ -51,6 +51,8 @@ def run_ruff(path: Path, *, fix: bool = True) -> None:
         subprocess.run(cmd, check=True)
         print(f'[✓] Ruff check {"fixed" if fix else "checked"} {path}')
     except subprocess.CalledProcessError as exc:
-        raise RuntimeError(
-            f'Ruff check reported issues (exit code {exc.returncode}).'
-        ) from exc
+        msg = (
+            f'Ruff check reported issues '
+            f'(exit code {exc.returncode}).'
+        )
+        raise RuntimeError(msg) from exc

--- a/src/hiperhealth/llm.py
+++ b/src/hiperhealth/llm.py
@@ -114,17 +114,18 @@ class LLMSettings:
     api_params: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        """Validate settings after initialization."""
-        if self.temperature < 0.0 or self.temperature > 2.0:
-            raise ValueError(
-                f"temperature must be between 0.0 and 2.0, got {self.temperature}"
-            )
-        if self.max_tokens < 1:
-            raise ValueError(
-                f"max_tokens must be positive, got {self.max_tokens}"
-            )
-        if not self.provider:
-            raise ValueError("provider cannot be empty")
+     """Validate settings after initialization."""
+    if self.temperature < 0.0 or self.temperature > 2.0:
+        raise ValueError(
+            f"temperature must be between 0.0 and 2.0, "
+            f"got {self.temperature}"
+        )
+    if self.max_tokens < 1:
+        raise ValueError(
+            f"max_tokens must be positive, got {self.max_tokens}"
+        )
+    if not self.provider:
+        raise ValueError("provider cannot be empty")
         
     @property
     def normalized_provider(self) -> str:

--- a/src/hiperhealth/llm.py
+++ b/src/hiperhealth/llm.py
@@ -113,6 +113,19 @@ class LLMSettings:
     persist_raw: bool = True
     api_params: dict[str, Any] = field(default_factory=dict)
 
+    def __post_init__(self) -> None:
+        """Validate settings after initialization."""
+        if self.temperature < 0.0 or self.temperature > 2.0:
+            raise ValueError(
+                f"temperature must be between 0.0 and 2.0, got {self.temperature}"
+            )
+        if self.max_tokens < 1:
+            raise ValueError(
+                f"max_tokens must be positive, got {self.max_tokens}"
+            )
+        if not self.provider:
+            raise ValueError("provider cannot be empty")
+        
     @property
     def normalized_provider(self) -> str:
         """


### PR DESCRIPTION
## Description
Adds input validation to `LLMSettings` dataclass to catch configuration errors early.

## Motivation
While exploring the codebase for my GSoC proposal, I noticed that invalid `temperature` or `max_tokens` values would only fail during API calls. This adds validation at initialization for better developer experience.

## Changes
- Added `__post_init__` method to validate:
  - `temperature` is between 0.0 and 2.0 (standard LLM range)
  - `max_tokens` is positive
  - `provider` is not empty

## Testing
- Follows existing dataclass pattern
- Validation runs automatically on object creation