### PR TITLE
fix(wearable): accept str paths in is_supported and _get_mime_type (#…

### DIFF
--- a/src/hiperhealth/skills/extraction/wearable.py
+++ b/src/hiperhealth/skills/extraction/wearable.py
@@ -163,9 +163,11 @@ class WearableDataFileExtractor(BaseWearableDataExtractor[FileInput]):
             # if it's a inmemory-temp file, validate it
             return self._validate_inmemory_file(file)
 
-        if isinstance(file, Path):
-            # if it's normal file, gets its extension
-            return file.suffix.replace('.', '') in self.allowed_extensions
+        if isinstance(file, (str, Path)):
+            # if it's a file path, check its extension
+            return (
+                Path(file).suffix.replace('.', '') in self.allowed_extensions
+            )
 
         return self._get_mime_type(file) in self.allowed_mimetypes
 
@@ -217,9 +219,9 @@ class WearableDataFileExtractor(BaseWearableDataExtractor[FileInput]):
             # Return cached mimetype
             return self._mimetype_cache[cache_key]
 
-        if isinstance(file, Path):
+        if isinstance(file, (str, Path)):
             self._mimetype_cache[cache_key] = cast(
-                MimeType, self.mime.from_file(file)
+                MimeType, self.mime.from_file(str(file))
             )
             return self._mimetype_cache[cache_key]
         elif isinstance(file, io.IOBase):
@@ -244,10 +246,10 @@ class WearableDataFileExtractor(BaseWearableDataExtractor[FileInput]):
           type: str
         """
         cache_key: str
-        if isinstance(file, Path):
-            cache_key = str(file.resolve())
+        if isinstance(file, (str, Path)):
+            cache_key = str(Path(file).resolve())
         else:
-            cache_key = str(id(file))  # Usar o id do objeto em memória
+            cache_key = str(id(file))  # use object id for in-memory files
         return cache_key
 
     def _is_json(self, file: FileInput) -> bool:

--- a/tests/test_extraction_wearable.py
+++ b/tests/test_extraction_wearable.py
@@ -144,3 +144,27 @@ def test_support_inmemory_csv(wearable_extractor):
     assert len(wearable_data) == 4
     assert wearable_data[0]['name'] == 'John Doe'
     assert wearable_data[1]['heart_rate'] == 80
+
+
+def test_is_supported_accepts_str_path(wearable_extractor):
+    """
+    title: is_supported should accept str paths, not just Path objects.
+    parameters:
+      wearable_extractor:
+        description: Value for wearable_extractor.
+    """
+    assert wearable_extractor.is_supported(str(CSV_FILE))
+    assert wearable_extractor.is_supported(str(JSON_FILE))
+    assert not wearable_extractor.is_supported(str(UNSUPPORTED_FILE))
+
+
+def test_extract_wearable_data_accepts_str_path(wearable_extractor):
+    """
+    title: extract_wearable_data should accept str paths.
+    parameters:
+      wearable_extractor:
+        description: Value for wearable_extractor.
+    """
+    wearable_data = wearable_extractor.extract_wearable_data(str(CSV_FILE))
+    assert isinstance(wearable_data, list)
+    assert len(wearable_data) > 0


### PR DESCRIPTION
## Pull Request description

`FileInput` type alias includes `str`, and the README shows usage like
`extract_wearable_data("path/to/data.csv")`, but the internal methods
only handled `Path` — causing a `TypeError` before extraction began.

**Root cause:** `is_supported()`, `_get_mime_type()`, and
`_get_cache_key()` checked `isinstance(file, Path)` but not `str`.
`_process_json_file` and `_process_csv_file` already handled `str`
correctly, so only the validation/detection layer was broken.

**Fix:** Changed all three methods to check
`isinstance(file, (str, Path))` and wrap with `Path()` where needed.

Fixes #215

## How to test these changes

- `pytest tests/test_extraction_wearable.py -v`

## Pull Request checklists

This PR is a:

- [x] bug-fix
- [ ] new feature
- [ ] maintenance

About this PR:

- [x] it includes tests.
- [x] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [x] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more complexity.
- [x] New and old tests passed locally.

## Additional information

2 new tests added in `tests/test_extraction_wearable.py`:
- `test_is_supported_accepts_str_path` — verifies `is_supported()` returns correct result for str CSV, JSON, and unsupported paths
- `test_extract_wearable_data_accepts_str_path` — verifies end-to-end extraction works with a str path

All 9 tests pass.
