### PR TITLE
fix(wearable): handle None values and negative integers in _process_r…

### DIFF
--- a/src/hiperhealth/skills/extraction/wearable.py
+++ b/src/hiperhealth/skills/extraction/wearable.py
@@ -321,7 +321,9 @@ class WearableDataFileExtractor(BaseWearableDataExtractor[FileInput]):
           type: dict[str, object]
         """
         for key, value in row.items():
-            if value.isnumeric():
+            if value is None:
+                row[key] = None
+            elif value.lstrip('-').isnumeric():
                 row[key] = int(value)
             elif is_float(value):
                 row[key] = float(value)

--- a/tests/test_extraction_wearable.py
+++ b/tests/test_extraction_wearable.py
@@ -144,3 +144,32 @@ def test_support_inmemory_csv(wearable_extractor):
     assert len(wearable_data) == 4
     assert wearable_data[0]['name'] == 'John Doe'
     assert wearable_data[1]['heart_rate'] == 80
+
+
+def test_process_row_handles_none_values(wearable_extractor):
+    """
+    title: _process_row should not crash when a CSV field value is None.
+    parameters:
+      wearable_extractor:
+        description: Value for wearable_extractor.
+    """
+    # Rows shorter than the header produce None values via csv.DictReader
+    raw_csv = b'name,age,score\nAlice,30'
+    some_csv = io.BytesIO(raw_csv)
+    result = wearable_extractor.extract_wearable_data(some_csv)
+    assert result[0]['score'] is None
+
+
+def test_process_row_handles_negative_integers(wearable_extractor):
+    """
+    title: _process_row should parse negative integers as int, not str.
+    parameters:
+      wearable_extractor:
+        description: Value for wearable_extractor.
+    """
+    raw_csv = b'timestamp,temperature\n2024-01-01,-5\n2024-01-02,-12'
+    some_csv = io.BytesIO(raw_csv)
+    result = wearable_extractor.extract_wearable_data(some_csv)
+    assert result[0]['temperature'] == -5
+    assert isinstance(result[0]['temperature'], int)
+    assert result[1]['temperature'] == -12


### PR DESCRIPTION
## Pull Request description

Two bugs in `_process_row()` in `src/hiperhealth/skills/extraction/wearable.py`:

**1. AttributeError on None values**
`csv.DictReader` yields `None` for fields when a row is shorter than the
header. Calling `value.isnumeric()` on `None` raised `AttributeError`.
Fix: guard with `if value is None` and preserve `None` as-is.

**2. Negative integers parsed as strings**
`'-60'.isnumeric()` returns `False` (the minus sign fails the check), so
negative integers were silently returned as strings instead of `int`.
Fix: use `value.lstrip('-').isnumeric()` to correctly parse signed integers.

Fixes #188

## How to test these changes

- `pytest tests/test_extraction_wearable.py -v`

## Pull Request checklists

This PR is a:

- [x] bug-fix
- [ ] new feature
- [ ] maintenance

About this PR:

- [x] it includes tests.
- [x] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [x] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more complexity.
- [x] New and old tests passed locally.

## Additional information

2 new tests in `tests/test_extraction_wearable.py`:
- `test_process_row_handles_none_values` — short row produces `None` field, no crash
- `test_process_row_handles_negative_integers` — `-5`, `-12` parsed as `int`, not `str`

All 9 tests pass.
