### PR TITLE
chore(security): avoid executing npx lifecycle hooks during release

### DIFF
--- a/.makim.yaml
+++ b/.makim.yaml
@@ -101,7 +101,7 @@ groups:
   release:
     vars:
       app: |
-        npx --yes \
+        env npm_config_ignore_scripts=true npx --yes \
         -p semantic-release \
         -p "@semantic-release/commit-analyzer" \
         -p "@semantic-release/release-notes-generator" \


### PR DESCRIPTION
## Pull Request description

This PR implements precautionary security remediation advice following the recent `npm` registry compromises that targeted postinstall hooks. 

Because `hiperhealth` is purely Python-based, it avoids `npm install` workflows natively. However, our `.makim.yaml` utilizes an automated `npx` step for `semantic-release` during CI builds. `npx --yes` inherently downloads the latest versions bypassing lockfiles.

**Changes made:**
- Updated `.makim.yaml` to prepend `npm_config_ignore_scripts=true` to the `semantic-release` execution step. This forces npm to drop any postinstall hooks that may be attached to plugins downloaded during the pipeline step, neutralizing a heavily used attack vector.

## How to test these changes

* Checkout the branch locally.
* Execute `makim release.dry` and verify the `semantic-release` workflow executes seamlessly without permission to run native scripts.

## Pull Request checklists

This PR is a:
- [ ] bug-fix
- [ ] new feature
- [x] maintenance

About this PR:
- [ ] it includes tests.
- [x] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [x] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:
- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more
      complexity.
- [x] New and old tests passed locally.



