### PR TITLE
Fix: Support string paths in extract_wearable_data

### DIFF
--- a/src/hiperhealth/skills/extraction/wearable.py
+++ b/src/hiperhealth/skills/extraction/wearable.py
@@ -126,6 +126,8 @@ class WearableDataFileExtractor(BaseWearableDataExtractor[FileInput]):
           type: list[dict[str, object]]
           description: Return value.
         """
+        if isinstance(file, str):
+            file = Path(file)
         self._validate_or_raise(file)
         return self._process_file(file)
 
@@ -159,6 +161,9 @@ class WearableDataFileExtractor(BaseWearableDataExtractor[FileInput]):
           type: bool
           description: Return value.
         """
+        if isinstance(file, str):
+            file = Path(file)
+
         if isinstance(file, (tempfile.SpooledTemporaryFile, io.BytesIO)):
             # if it's a inmemory-temp file, validate it
             return self._validate_inmemory_file(file)


### PR DESCRIPTION
solve #215 
This update resolves a type error bug where the extract_wearable_data public API was intended to accept file paths as string types (str), but would fail during validation when forwarding the string to internal helper methods like _get_mime_type(). To fix this, new logic was added to both extract_wearable_data and the is_supported method to immediately intercept str inputs and convert them into pathlib.Path objects upon entry. This normalizes the input early in the pipeline, ensuring seamless compatibility with the existing downstream validation logic without requiring structural changes to the internal file processors.