### PR TITLE
Fix/extractor path normalization

### DIFF
--- a/src/hiperhealth/skills/extraction/wearable.py
+++ b/src/hiperhealth/skills/extraction/wearable.py
@@ -126,6 +126,8 @@ class WearableDataFileExtractor(BaseWearableDataExtractor[FileInput]):
           type: list[dict[str, object]]
           description: Return value.
         """
+        if isinstance(file, str):
+            file = Path(file)
         self._validate_or_raise(file)
         return self._process_file(file)
 
@@ -159,6 +161,9 @@ class WearableDataFileExtractor(BaseWearableDataExtractor[FileInput]):
           type: bool
           description: Return value.
         """
+        if isinstance(file, str):
+            file = Path(file)
+
         if isinstance(file, (tempfile.SpooledTemporaryFile, io.BytesIO)):
             # if it's a inmemory-temp file, validate it
             return self._validate_inmemory_file(file)
@@ -211,6 +216,9 @@ class WearableDataFileExtractor(BaseWearableDataExtractor[FileInput]):
           type: str
           description: Return value.
         """
+        if isinstance(file, str):
+            file = Path(file)
+
         cache_key = self._get_cache_key(file)
 
         if cache_key in self._mimetype_cache:


### PR DESCRIPTION
solve #234 
This PR fixes a critical bug in WearableDataFileExtractor where string file paths would incorrectly cause a TypeError when handled by internal detection methods.


The class's FileInput type contract explicitly dictates that raw strings (str) are supported. The primary extract_wearable_data method correctly honors this by normalizing strings into pathlib.Path objects at the start of execution.

However, the detection methods (_is_json, _is_csv) and caching mechanisms bypassed this normalization and passed raw strings directly to _get_mime_type(). Since _get_mime_type() strictly expected a Path or IOBase object as the foundation for the python-magic scanner, this contradiction led to an immediate application crash. Furthermore, it compromised the cache keys by attempting to id() the string entirely rather than its filesystem footprint.