### PR TITLE
Security: Implement multi-layer API key masking and data scrubbing

### DIFF
--- a/src/hiperhealth/llm.py
+++ b/src/hiperhealth/llm.py
@@ -113,6 +113,13 @@ class LLMSettings:
     persist_raw: bool = True
     api_params: dict[str, Any] = field(default_factory=dict)
 
+    def __post_init__(self) -> None:
+        """
+        title: Ensure api_key is always stored as a SecretStr.
+        """
+        if isinstance(self.api_key, str):
+            object.__setattr__(self, 'api_key', SecretStr(self.api_key))
+
     @property
     def normalized_provider(self) -> str:
         """
@@ -410,7 +417,7 @@ def load_llm_settings(
     return LLMSettings(
         provider=provider,
         model=model,
-        api_key=SecretStr(api_key) if api_key else '',
+        api_key=api_key or '',
         engine=engine,
         temperature=temperature,
         max_tokens=max_tokens,

--- a/src/hiperhealth/llm.py
+++ b/src/hiperhealth/llm.py
@@ -410,7 +410,7 @@ def load_llm_settings(
     return LLMSettings(
         provider=provider,
         model=model,
-        api_key=api_key,
+        api_key=SecretStr(api_key) if api_key else '',
         engine=engine,
         temperature=temperature,
         max_tokens=max_tokens,

--- a/src/hiperhealth/llm.py
+++ b/src/hiperhealth/llm.py
@@ -10,7 +10,7 @@ import os
 from dataclasses import dataclass, field, replace
 from typing import Any, Callable, Protocol, TypeVar, cast
 
-from pydantic import BaseModel
+from pydantic import BaseModel, SecretStr
 
 TModel = TypeVar('TModel', bound=BaseModel)
 
@@ -86,7 +86,7 @@ class LLMSettings:
         type: str
         description: Value for model.
       api_key:
-        type: str
+        type: SecretStr | str
         description: Value for api_key.
       engine:
         type: str
@@ -106,7 +106,7 @@ class LLMSettings:
 
     provider: str = 'openai'
     model: str = ''
-    api_key: str = ''
+    api_key: SecretStr | str = field(default='', repr=False)
     engine: str = ''
     temperature: float = 0.0
     max_tokens: int = 4096
@@ -220,7 +220,11 @@ class LLMSettings:
         kwargs['temperature'] = self.temperature
         kwargs['max_tokens'] = self.max_tokens
         if self.api_key:
-            kwargs['api_key'] = self.api_key
+            kwargs['api_key'] = (
+                self.api_key.get_secret_value()
+                if hasattr(self.api_key, 'get_secret_value')
+                else self.api_key
+            )
         return kwargs
 
 

--- a/src/hiperhealth/pipeline/runner.py
+++ b/src/hiperhealth/pipeline/runner.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, Any
 from hiperhealth.pipeline.context import AuditEntry, PipelineContext
 from hiperhealth.pipeline.session import Inquiry
 from hiperhealth.pipeline.skill import Skill
-from hiperhealth.utils import _scrub_sensitive_data
 
 if TYPE_CHECKING:
     from hiperhealth.pipeline.registry import SkillRegistry
@@ -157,7 +156,7 @@ class StageRunner:
         returns:
           type: PipelineContext
         """
-        ctx.extras['_run_kwargs'] = _scrub_sensitive_data(kwargs)
+        ctx.extras['_run_kwargs'] = kwargs
         return self._run_stage(stage, ctx, disabled_skills=disabled_skills)
 
     def run_many(

--- a/src/hiperhealth/pipeline/runner.py
+++ b/src/hiperhealth/pipeline/runner.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
     from hiperhealth.pipeline.registry import SkillRegistry
     from hiperhealth.pipeline.session import Session
 
+_SENSITIVE_PATTERNS = {'key', 'token', 'secret', 'password', 'pwd'}
+
 
 class StageRunner:
     """
@@ -156,7 +158,7 @@ class StageRunner:
         returns:
           type: PipelineContext
         """
-        ctx.extras['_run_kwargs'] = kwargs
+        ctx.extras['_run_kwargs'] = _scrub_sensitive_data(kwargs)
         return self._run_stage(stage, ctx, disabled_skills=disabled_skills)
 
     def run_many(
@@ -390,3 +392,48 @@ class StageRunner:
         )
         session.update_from_context(stage, ctx)
         return session
+
+
+def _scrub_sensitive_data(data: Any) -> Any:
+    """
+    title: Recursively mask sensitive fields in dictionaries or objects.
+    parameters:
+      data:
+        type: Any
+    returns:
+      type: Any
+    """
+    if isinstance(data, dict):
+        return {
+            k: '********' if _is_sensitive_key(k) else _scrub_sensitive_data(v)
+            for k, v in data.items()
+        }
+    if isinstance(data, (list, tuple)):
+        return [_scrub_sensitive_data(i) for i in data]
+
+    # Handle LLMSettings specifically if it appears in kwargs
+    try:
+        from hiperhealth.llm import LLMSettings
+
+        if isinstance(data, LLMSettings):
+            return 'LLMSettings(masked)'
+    except ImportError:
+        pass
+
+    return data
+
+
+def _is_sensitive_key(key: str) -> bool:
+    """
+    title: Check if a key name suggests it contains sensitive information.
+    parameters:
+      key:
+        type: str
+    returns:
+      type: bool
+    """
+    name = key.lower()
+    return any(pattern in name for pattern in _SENSITIVE_PATTERNS)
+
+
+__all__ = ['StageRunner']

--- a/src/hiperhealth/pipeline/runner.py
+++ b/src/hiperhealth/pipeline/runner.py
@@ -11,12 +11,11 @@ from typing import TYPE_CHECKING, Any
 from hiperhealth.pipeline.context import AuditEntry, PipelineContext
 from hiperhealth.pipeline.session import Inquiry
 from hiperhealth.pipeline.skill import Skill
+from hiperhealth.utils import _scrub_sensitive_data
 
 if TYPE_CHECKING:
     from hiperhealth.pipeline.registry import SkillRegistry
     from hiperhealth.pipeline.session import Session
-
-_SENSITIVE_PATTERNS = {'key', 'token', 'secret', 'password', 'pwd'}
 
 
 class StageRunner:
@@ -392,48 +391,6 @@ class StageRunner:
         )
         session.update_from_context(stage, ctx)
         return session
-
-
-def _scrub_sensitive_data(data: Any) -> Any:
-    """
-    title: Recursively mask sensitive fields in dictionaries or objects.
-    parameters:
-      data:
-        type: Any
-    returns:
-      type: Any
-    """
-    if isinstance(data, dict):
-        return {
-            k: '********' if _is_sensitive_key(k) else _scrub_sensitive_data(v)
-            for k, v in data.items()
-        }
-    if isinstance(data, (list, tuple)):
-        return [_scrub_sensitive_data(i) for i in data]
-
-    # Handle LLMSettings specifically if it appears in kwargs
-    try:
-        from hiperhealth.llm import LLMSettings
-
-        if isinstance(data, LLMSettings):
-            return 'LLMSettings(masked)'
-    except ImportError:
-        pass
-
-    return data
-
-
-def _is_sensitive_key(key: str) -> bool:
-    """
-    title: Check if a key name suggests it contains sensitive information.
-    parameters:
-      key:
-        type: str
-    returns:
-      type: bool
-    """
-    name = key.lower()
-    return any(pattern in name for pattern in _SENSITIVE_PATTERNS)
 
 
 __all__ = ['StageRunner']

--- a/src/hiperhealth/pipeline/session.py
+++ b/src/hiperhealth/pipeline/session.py
@@ -21,6 +21,7 @@ import pyarrow.parquet as pq
 from pydantic import BaseModel
 
 from hiperhealth.pipeline.context import PipelineContext
+from hiperhealth.utils import _scrub_sensitive_data
 
 # ── Inquiry model ──────────────────────────────────────────────────
 
@@ -409,7 +410,7 @@ class Session:
             'stage': stage,
             'skill_name': skill_name,
             'data': json.dumps(
-                data if data is not None else {},
+                _scrub_sensitive_data(data) if data is not None else {},
                 ensure_ascii=False,
                 default=str,
             ),

--- a/src/hiperhealth/utils.py
+++ b/src/hiperhealth/utils.py
@@ -3,6 +3,7 @@ title: HiPerHealth utility functions.
 """
 
 import datetime
+import re
 
 from typing import Any
 
@@ -74,7 +75,17 @@ def make_json_serializable(obj: Any) -> Any:
         return obj
 
 
-_SENSITIVE_PATTERNS = {'key', 'token', 'secret', 'password', 'pwd'}
+_SENSITIVE_SUFFIXES = {'key', 'token'}
+_SENSITIVE_WORDS = {
+    'secret',
+    'password',
+    'pwd',
+    'credential',
+    'credentials',
+    'cookie',
+    'authorization',
+    'auth',
+}
 
 
 def _scrub_sensitive_data(data: Any) -> Any:
@@ -118,4 +129,16 @@ def _is_sensitive_key(key: str) -> bool:
       type: bool
     """
     name = key.lower()
-    return any(pattern in name for pattern in _SENSITIVE_PATTERNS)
+    # Strip trailing digits to handle e.g. password123
+    name = re.sub(r'\d+$', '', name)
+    tokens = re.split(r'[-_]', name)
+    if not tokens:
+        return False
+
+    if set(tokens) & _SENSITIVE_WORDS:
+        return True
+
+    if tokens[-1] in _SENSITIVE_SUFFIXES:
+        return True
+
+    return False

--- a/src/hiperhealth/utils.py
+++ b/src/hiperhealth/utils.py
@@ -91,8 +91,10 @@ def _scrub_sensitive_data(data: Any) -> Any:
             k: '********' if _is_sensitive_key(k) else _scrub_sensitive_data(v)
             for k, v in data.items()
         }
-    if isinstance(data, (list, tuple)):
+    if isinstance(data, list):
         return [_scrub_sensitive_data(i) for i in data]
+    if isinstance(data, tuple):
+        return tuple(_scrub_sensitive_data(i) for i in data)
 
     # Handle LLMSettings specifically if it appears in context data
     try:

--- a/src/hiperhealth/utils.py
+++ b/src/hiperhealth/utils.py
@@ -72,3 +72,48 @@ def make_json_serializable(obj: Any) -> Any:
         return obj.isoformat()
     else:
         return obj
+
+
+_SENSITIVE_PATTERNS = {'key', 'token', 'secret', 'password', 'pwd'}
+
+
+def _scrub_sensitive_data(data: Any) -> Any:
+    """
+    title: Recursively mask sensitive fields in dictionaries or objects.
+    parameters:
+      data:
+        type: Any
+    returns:
+      type: Any
+    """
+    if isinstance(data, dict):
+        return {
+            k: '********' if _is_sensitive_key(k) else _scrub_sensitive_data(v)
+            for k, v in data.items()
+        }
+    if isinstance(data, (list, tuple)):
+        return [_scrub_sensitive_data(i) for i in data]
+
+    # Handle LLMSettings specifically if it appears in context data
+    try:
+        from hiperhealth.llm import LLMSettings
+
+        if isinstance(data, LLMSettings):
+            return 'LLMSettings(masked)'
+    except ImportError:
+        pass
+
+    return data
+
+
+def _is_sensitive_key(key: str) -> bool:
+    """
+    title: Check if a key name suggests it contains sensitive information.
+    parameters:
+      key:
+        type: str
+    returns:
+      type: bool
+    """
+    name = key.lower()
+    return any(pattern in name for pattern in _SENSITIVE_PATTERNS)

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -49,7 +49,7 @@ def test_load_diagnostics_llm_settings_prefers_specific_env(monkeypatch):
 
     assert settings.provider == 'ollama'
     assert settings.model == 'llama3.2:3b'
-    assert settings.api_key == ''
+    assert settings.api_key.get_secret_value() == ''
     assert settings.api_params['base_url'] == 'http://localhost:11434/v1'
 
 
@@ -373,3 +373,22 @@ def test_to_litellm_kwargs_always_includes_temperature_and_max_tokens():
         kwargs = settings.to_litellm_kwargs()
         assert kwargs['temperature'] == 0.0
         assert kwargs['max_tokens'] == 4096
+
+
+def test_llm_settings_api_key_converted_to_secret_str():
+    """
+    title: LLMSettings should convert string api_key to SecretStr on init.
+    """
+    settings = LLMSettings(api_key='plain-secret')
+    assert 'plain-secret' not in repr(settings)
+    assert settings.api_key.get_secret_value() == 'plain-secret'
+
+
+def test_llm_settings_with_overrides_api_key_converted():
+    """
+    title: with_overrides should convert string api_key to SecretStr.
+    """
+    base = LLMSettings(api_key='initial')
+    overridden = base.with_overrides(api_key='new-secret')
+    assert 'new-secret' not in repr(overridden)
+    assert overridden.api_key.get_secret_value() == 'new-secret'

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -472,3 +472,48 @@ class TestStageRunner:
         assert Stage.EXAM in ctx2.results
         # Audit from both runs
         assert len(ctx2.audit) >= 3  # from first run
+
+    def test_run_kwargs_preserve_llm_settings(self) -> None:
+        """
+        title: StageRunner kwargs should remain uncorrupted during execution.
+        """
+        from hiperhealth.llm import LLMSettings
+
+        class _DiagnosticsCheckSkill(BaseSkill):
+            def __init__(self) -> None:
+                """
+                title: Initialize a dummy check skill.
+                """
+                super().__init__(
+                    SkillMetadata(name='diag_check', stages=(Stage.DIAGNOSIS,))
+                )
+
+            def execute(
+                self, stage: str, ctx: PipelineContext
+            ) -> PipelineContext:
+                """
+                title: Assert llm_settings are correctly passed in kwargs.
+                parameters:
+                  stage:
+                    type: str
+                  ctx:
+                    type: PipelineContext
+                returns:
+                  type: PipelineContext
+                """
+                settings = ctx.extras.get('_run_kwargs', {}).get(
+                    'llm_settings'
+                )
+                assert isinstance(settings, LLMSettings)
+                assert settings.api_key.get_secret_value() == 'real-secret'
+                ctx.results[stage] = 'success'
+                return ctx
+
+        skill = _DiagnosticsCheckSkill()
+        runner = StageRunner(skills=[skill])
+        settings = LLMSettings(api_key='real-secret')
+
+        result = runner.run(
+            Stage.DIAGNOSIS, PipelineContext(), llm_settings=settings
+        )
+        assert result.results[Stage.DIAGNOSIS] == 'success'

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -591,3 +591,27 @@ class TestCheckRequirements:
 
         inquiries = runner.check_requirements(Stage.TREATMENT, session)
         assert len(inquiries) == 0
+
+    def test_clinical_data_sensitive_substring_persistence(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        title: Keys with sensitive substrings should persist uncorrupted.
+        parameters:
+          tmp_path:
+            type: Path
+        """
+        path = tmp_path / 'session.parquet'
+        session = Session.create(path)
+        session.set_clinical_data(
+            {
+                'monkeypox_exposure': False,
+                'keyboard_layout': 'qwerty',
+                'token_count': 42,
+            }
+        )
+
+        loaded = Session.load(path)
+        assert loaded.clinical_data['monkeypox_exposure'] is False
+        assert loaded.clinical_data['keyboard_layout'] == 'qwerty'
+        assert loaded.clinical_data['token_count'] == 42

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -143,6 +143,62 @@ class TestDiagnosticsSkill:
         parsed = json.loads(calls[0]['user'])
         assert parsed['symptoms'] == 'fever, cough'
 
+    def test_execute_diagnosis_stage_with_explicit_llm_settings(
+        self, monkeypatch: Any
+    ) -> None:
+        """
+        title: DiagnosticsSkill should pass explicit llm_settings.
+        parameters:
+          monkeypatch:
+            type: Any
+            description: Value for monkeypatch.
+        """
+        from hiperhealth.llm import LLMSettings
+
+        fake_result = LLMDiagnosis(summary='Test', options=[])
+        calls: list[dict[str, Any]] = []
+
+        def _fake_chat(
+            system: str,
+            user: str,
+            *,
+            session_id: str | None = None,
+            llm: Any = None,
+            llm_settings: Any = None,
+        ) -> LLMDiagnosis:
+            """
+            title: Capture diagnosis chat calls to verify llm_settings.
+            parameters:
+              system:
+                type: str
+              user:
+                type: str
+              session_id:
+                type: str | None
+              llm:
+                type: Any
+              llm_settings:
+                type: Any
+            returns:
+              type: LLMDiagnosis
+            """
+            calls.append({'llm_settings': llm_settings})
+            return fake_result
+
+        monkeypatch.setattr(diag_skill_mod, 'chat', _fake_chat)
+
+        skill = DiagnosticsSkill()
+        ctx = PipelineContext(patient={'symptoms': 'fever'})
+        settings = LLMSettings(api_key='explicit-secret-key')
+        runner = StageRunner(skills=[skill])
+        runner.run(Stage.DIAGNOSIS, ctx, llm_settings=settings)
+
+        assert len(calls) == 1
+        captured_settings = calls[0]['llm_settings']
+        assert isinstance(captured_settings, LLMSettings)
+        secret_val = captured_settings.api_key.get_secret_value()
+        assert secret_val == 'explicit-secret-key'
+
     def test_execute_exam_stage_uses_diagnosis_results(
         self, monkeypatch: Any
     ) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,12 @@ title: Test HiPerHealth utility functions module.
 
 import datetime
 
-from hiperhealth.utils import is_float, make_json_serializable
+from hiperhealth.utils import (
+    _is_sensitive_key,
+    _scrub_sensitive_data,
+    is_float,
+    make_json_serializable,
+)
 
 
 def test_is_float():
@@ -48,3 +53,53 @@ def test_make_json_serializable_dict():
         'b': [1, 2, '2023-01-02'],
         'c': {'nested': '2023-01-03'},
     }
+
+
+def test_is_sensitive_key():
+    """
+    title: Test detection of sensitive keys.
+    """
+    # Expected matches
+    assert _is_sensitive_key('api_key')
+    assert _is_sensitive_key('TOKEN')
+    assert _is_sensitive_key('secret_value')
+    assert _is_sensitive_key('password123')
+    assert _is_sensitive_key('DB_PWD')
+
+    # False positives (should not match)
+    assert not _is_sensitive_key('api_endpoint')
+    assert not _is_sensitive_key('user_name')
+    assert not _is_sensitive_key('configuration')
+    assert not _is_sensitive_key('db_port')
+
+
+def test_scrub_sensitive_data():
+    """
+    title: Test scrubbing of sensitive data recursively.
+    """
+    data = {
+        'api_key': 'secret123',
+        'public_info': 'hello',
+        'nested': {
+            'token': 'abc',
+            'safe': 'data'
+        },
+        'list_data': [
+            {'password': 'pwd', 'id': 1},
+            (1, 2, {'secret': 'hidden'})
+        ]
+    }
+
+    scrubbed = _scrub_sensitive_data(data)
+
+    assert scrubbed['api_key'] == '********'
+    assert scrubbed['public_info'] == 'hello'
+    assert scrubbed['nested']['token'] == '********'
+    assert scrubbed['nested']['safe'] == 'data'
+    assert scrubbed['list_data'][0]['password'] == '********'
+    assert scrubbed['list_data'][0]['id'] == 1
+    # Check that tuple type is preserved
+    assert isinstance(scrubbed['list_data'][1], tuple)
+    assert scrubbed['list_data'][1][0] == 1
+    assert scrubbed['list_data'][1][2]['secret'] == '********'
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -80,14 +80,11 @@ def test_scrub_sensitive_data():
     data = {
         'api_key': 'secret123',
         'public_info': 'hello',
-        'nested': {
-            'token': 'abc',
-            'safe': 'data'
-        },
+        'nested': {'token': 'abc', 'safe': 'data'},
         'list_data': [
             {'password': 'pwd', 'id': 1},
-            (1, 2, {'secret': 'hidden'})
-        ]
+            (1, 2, {'secret': 'hidden'}),
+        ],
     }
 
     scrubbed = _scrub_sensitive_data(data)
@@ -102,4 +99,3 @@ def test_scrub_sensitive_data():
     assert isinstance(scrubbed['list_data'][1], tuple)
     assert scrubbed['list_data'][1][0] == 1
     assert scrubbed['list_data'][1][2]['secret'] == '********'
-

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -65,12 +65,23 @@ def test_is_sensitive_key():
     assert _is_sensitive_key('secret_value')
     assert _is_sensitive_key('password123')
     assert _is_sensitive_key('DB_PWD')
+    assert _is_sensitive_key('authorization')
+    assert _is_sensitive_key('auth_header')
+    assert _is_sensitive_key('credentials')
+    assert _is_sensitive_key('cookie')
+    assert _is_sensitive_key('access_token')
+    assert _is_sensitive_key('refresh_token')
+    assert _is_sensitive_key('client_secret')
 
     # False positives (should not match)
     assert not _is_sensitive_key('api_endpoint')
     assert not _is_sensitive_key('user_name')
     assert not _is_sensitive_key('configuration')
     assert not _is_sensitive_key('db_port')
+    assert not _is_sensitive_key('monkeypox_exposure')
+    assert not _is_sensitive_key('keyboard_layout')
+    assert not _is_sensitive_key('key_findings')
+    assert not _is_sensitive_key('token_count')
 
 
 def test_scrub_sensitive_data():


### PR DESCRIPTION

## Pull Request description
This PR hardens the library against accidental API key and credential leaks. It addresses multiple "leakage surfaces" where sensitive data was previously exposed in plain text.

Changes

- Upgraded the `api_key` field in `LLMSettings` to use `pydantic.SecretStr`. This ensures that the key is automatically masked during both `repr()` (debugging logs) and JSON serialization.
- Updated `to_litellm_kwargs` to only reveal the raw secret value at the moment of the internal AI request using `.get_secret_value()`.
-Implemented a recursive sensitive-data scrubber in StageRunner.
  - Any keyword arguments passed to `run()` that contain sensitive patterns are now automatically masked as *s before being stored in the PipelineContext extras.
  - This prevents secrets from being written to session Parquet files on disk or sent to web frontends in JSON payloads.

## How to test these changes
1. Test Representation Masking- Verifies that sensitive keys are hidden from console logs, debuggers, or system error reports where standard object printing occurs. 
```
export PYTHONPATH=$PYTHONPATH:$(pwd)/src
python3 -c "from hiperhealth.llm import LLMSettings; from pydantic import SecretStr; settings = LLMSettings(api_key=SecretStr('REAL_KEY')); print(settings)"
```
Before: 
<img width="1204" height="58" alt="image" src="https://github.com/user-attachments/assets/6a807929-a4df-4bd6-b5a4-45de2b532e7b" />


After:
<img width="1130" height="48" alt="image" src="https://github.com/user-attachments/assets/33757356-f111-49f1-93fa-7eb8e81e9d0b" />

2. Test Runner Context Scrubbing- Ensures that secrets passed as dynamic arguments to the pipeline engine are scrubbed before entering the shared context dictionary. This prevents secrets from being shared between skills or visible in the runtime extras.
```
export PYTHONPATH=$PYTHONPATH:$(pwd)/src
python3 -c "from hiperhealth.pipeline.runner import StageRunner; from hiperhealth.pipeline.context import PipelineContext; runner = StageRunner(); ctx = PipelineContext(); runner.run(stage='intake', ctx=ctx, my_private_key='SECRET_VALUE'); print(ctx.extras['_run_kwargs'])"
```
Before: 
<img width="1234" height="70" alt="image" src="https://github.com/user-attachments/assets/b4461798-2041-49d2-8c8f-96b0404fce13" />

After:
<img width="1241" height="78" alt="image" src="https://github.com/user-attachments/assets/761932a8-4e79-429e-9f9d-d57d4d7e399b" />

3.  This test confirms data is scrubbed right before hitting the disk. It ensures that no secret survives in a Parquet session file, even if it was manually added by a custom skill.
```
export PYTHONPATH=$PYTHONPATH:$(pwd)/src
python3 -c "from pathlib import Path; from hiperhealth.pipeline.session import Session; import pyarrow.parquet as pq; p = Path('safety_test.parquet'); s = Session.create(p); s.record_event('manual_injection', data={'hidden_secret': 'SHOULD_NOT_BE_SAVED'}); table = pq.read_table(p); print('Parquet Data:', table.column('data').to_pylist()); p.unlink()"
```

<img width="1235" height="95" alt="image" src="https://github.com/user-attachments/assets/018fd836-621c-44f4-84e6-78df9dc1cdf7" />


4.  Verify Internal Functionality ( Just to show, it is still correctly passing keys to the AI engine internally.)
```
export PYTHONPATH=$PYTHONPATH:$(pwd)/src
python3 -c "from hiperhealth.llm import LLMSettings; from pydantic import SecretStr; settings = LLMSettings(model='gpt-4', api_key=SecretStr('REAL_KEY')); print('Internal Key:', settings.to_litellm_kwargs()['api_key'])"
```

<img width="1240" height="73" alt="image" src="https://github.com/user-attachments/assets/c4653ca8-5404-4ca4-bc14-4d7624d91dbc" />


  

## Pull Request checklists

This PR is a:

- [ ] bug-fix
- [ ] new feature
- [x] maintenance

About this PR:

- [x] it includes tests.
- [ ] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [x] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more
      complexity.
- [x] New and old tests passed locally.

