### PR TITLE
chore: remove fhirx mypy override

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,13 +107,6 @@ plugins = [
   "pydantic.mypy",
 ]
 
-[[tool.mypy.overrides]]
-module = "hiperhealth.schema.fhirx"
-disable_error_code = [
-  "name-defined",
-  "valid-type",
-]
-
 [tool.pytest.ini_options]
 testpaths = [
     "tests",


### PR DESCRIPTION
- Remove a stale mypy override for hiperhealth.schema.fhirx in pyproject.toml.
- The module is no longer present in the codebase, so the override is unused.
- This keeps type-checking config clean and avoids dead config entries.

## How to test these changes

<!-- Example:

* run `$ abc -p 1234`
* open the web browser with url localhost:1234
* ...
-->

- `...`

<!-- Modify the options to suit your project. -->

## Pull Request checklists

This PR is a:

- [ ] maintenance
- [ ] new feature
- [ ] bug-fix

About this PR:

- [ ] it includes tests.
- [ ] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [ ] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more
      complexity.
- [ ] New and old tests passed locally.

## Additional information

<!-- Add any screenshot that helps to show the changes proposed -->

<!-- Add any other extra information that would help to understand the changes proposed by this PR -->

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved
```
