### PR TITLE
feat(session): add Session.summary() snapshot method

### DIFF
--- a/src/hiperhealth/pipeline/session.py
+++ b/src/hiperhealth/pipeline/session.py
@@ -468,7 +468,10 @@ class Session:
         """
         title: Load session events from the parquet file.
         """
-        table = pq.read_table(self.path, schema=SESSION_SCHEMA)  # type: ignore
+        import typing
+
+        read_fn = typing.cast(typing.Callable[..., pa.Table], pq.read_table)
+        table = read_fn(self.path, schema=SESSION_SCHEMA)
         rows = table.to_pylist()
         self._events = rows
         # Recover language from first clinical_data_set if present
@@ -488,7 +491,10 @@ class Session:
             table = SESSION_SCHEMA.empty_table()
         else:
             table = pa.Table.from_pylist(self._events, schema=SESSION_SCHEMA)
-        pq.write_table(table, self.path)  # type: ignore
+        import typing
+
+        write_fn = typing.cast(typing.Callable[..., None], pq.write_table)
+        write_fn(table, self.path)
 
 
 __all__ = ['SESSION_SCHEMA', 'Inquiry', 'Session']

--- a/src/hiperhealth/pipeline/session.py
+++ b/src/hiperhealth/pipeline/session.py
@@ -334,18 +334,25 @@ class Session:
         completed = self.stages_completed
         completed_set = set(completed)
         pending_inquiries = self.pending_inquiries
+
+        stages_pending: list[str] = []
+        for s in Stage:
+            if s.value not in completed_set:
+                stages_pending.append(s.value)
+
+        required_inquiries: int = 0
+        for i in pending_inquiries:
+            if i.priority == 'required':
+                required_inquiries += 1
+
         return {
             'session_id': self.path.stem,
             'language': self._language,
             'clinical_data_fields': len(self.clinical_data),
             'stages_completed': list(completed),
-            'stages_pending': [
-                s.value for s in Stage if s.value not in completed_set
-            ],
+            'stages_pending': stages_pending,
             'pending_inquiries': len(pending_inquiries),
-            'required_inquiries': sum(
-                1 for i in pending_inquiries if i.priority == 'required'
-            ),
+            'required_inquiries': required_inquiries,
             'total_events': len(self._events),
         }
 

--- a/src/hiperhealth/pipeline/session.py
+++ b/src/hiperhealth/pipeline/session.py
@@ -461,7 +461,7 @@ class Session:
         """
         title: Load session events from the parquet file.
         """
-        table = pq.read_table(self.path, schema=SESSION_SCHEMA)
+        table = pq.read_table(self.path, schema=SESSION_SCHEMA)  # type: ignore[no-untyped-call]
         rows = table.to_pylist()
         self._events = rows
         # Recover language from first clinical_data_set if present
@@ -481,7 +481,7 @@ class Session:
             table = SESSION_SCHEMA.empty_table()
         else:
             table = pa.Table.from_pylist(self._events, schema=SESSION_SCHEMA)
-        pq.write_table(table, self.path)
+        pq.write_table(table, self.path)  # type: ignore[no-untyped-call]
 
 
 __all__ = ['SESSION_SCHEMA', 'Inquiry', 'Session']

--- a/src/hiperhealth/pipeline/session.py
+++ b/src/hiperhealth/pipeline/session.py
@@ -21,6 +21,7 @@ import pyarrow.parquet as pq
 from pydantic import BaseModel
 
 from hiperhealth.pipeline.context import PipelineContext
+from hiperhealth.pipeline.stages import Stage
 
 # ── Inquiry model ──────────────────────────────────────────────────
 
@@ -308,6 +309,45 @@ class Session:
                 'values': values,
             },
         )
+
+    def summary(self) -> dict[str, Any]:
+        """
+        title: Return a plain-dict snapshot of the current session state.
+        summary: |-
+          Provides a single, JSON-serializable overview of the session
+          without performing any additional I/O.  Useful for logging,
+          notebook display, and integration-layer diagnostics.
+
+          Returned keys:
+
+          - session_id: filename stem of the underlying parquet file.
+          - language: session language code.
+          - clinical_data_fields: number of patient data fields collected.
+          - stages_completed: ordered list of stages that have already run.
+          - stages_pending: standard Stage enum members not yet completed.
+          - pending_inquiries: total count of unanswered inquiry items.
+          - required_inquiries: count of unanswered 'required'-priority items.
+          - total_events: raw number of events in the event log.
+        returns:
+          type: dict[str, Any]
+        """
+        completed = self.stages_completed
+        completed_set = set(completed)
+        pending_inquiries = self.pending_inquiries
+        return {
+            'session_id': self.path.stem,
+            'language': self._language,
+            'clinical_data_fields': len(self.clinical_data),
+            'stages_completed': list(completed),
+            'stages_pending': [
+                s.value for s in Stage if s.value not in completed_set
+            ],
+            'pending_inquiries': len(pending_inquiries),
+            'required_inquiries': sum(
+                1 for i in pending_inquiries if i.priority == 'required'
+            ),
+            'total_events': len(self._events),
+        }
 
     # ── Context bridge ─────────────────────────────────────────────
 

--- a/src/hiperhealth/pipeline/session.py
+++ b/src/hiperhealth/pipeline/session.py
@@ -468,7 +468,7 @@ class Session:
         """
         title: Load session events from the parquet file.
         """
-        table = pq.read_table(self.path, schema=SESSION_SCHEMA)  # type: ignore[no-untyped-call]
+        table = pq.read_table(self.path, schema=SESSION_SCHEMA)  # type: ignore
         rows = table.to_pylist()
         self._events = rows
         # Recover language from first clinical_data_set if present
@@ -488,7 +488,7 @@ class Session:
             table = SESSION_SCHEMA.empty_table()
         else:
             table = pa.Table.from_pylist(self._events, schema=SESSION_SCHEMA)
-        pq.write_table(table, self.path)  # type: ignore[no-untyped-call]
+        pq.write_table(table, self.path)  # type: ignore
 
 
 __all__ = ['SESSION_SCHEMA', 'Inquiry', 'Session']

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -640,7 +640,9 @@ class TestSessionSummary:
 
     def test_summary_after_stage_run(self, tmp_path: Path) -> None:
         """
-        title: Completed stages should appear in summary and leave others pending.
+        title: |-
+          Completed stages should appear in summary and leave others
+          pending.
         parameters:
           tmp_path:
             type: Path
@@ -709,7 +711,10 @@ class TestSessionSummary:
         restored = json.loads(serialized)
 
         assert restored['stages_completed'] == result['stages_completed']
-        assert restored['clinical_data_fields'] == result['clinical_data_fields']
+        assert (
+            restored['clinical_data_fields']
+            == result['clinical_data_fields']
+        )
 
     def test_summary_session_id_is_filename_stem(self, tmp_path: Path) -> None:
         """

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -4,6 +4,8 @@ title: Tests for the parquet-backed session and assess flow.
 
 from __future__ import annotations
 
+import json
+
 from pathlib import Path
 
 from hiperhealth.pipeline import (
@@ -694,8 +696,6 @@ class TestSessionSummary:
           tmp_path:
             type: Path
         """
-        import json
-
         path = tmp_path / 'session.parquet'
         session = Session.create(path)
         session.set_clinical_data({'symptoms': 'headache'})

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -712,8 +712,7 @@ class TestSessionSummary:
 
         assert restored['stages_completed'] == result['stages_completed']
         assert (
-            restored['clinical_data_fields']
-            == result['clinical_data_fields']
+            restored['clinical_data_fields'] == result['clinical_data_fields']
         )
 
     def test_summary_session_id_is_filename_stem(self, tmp_path: Path) -> None:
@@ -729,4 +728,3 @@ class TestSessionSummary:
         result = session.summary()
 
         assert result['session_id'] == 'visit_2026_07_08'
-

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -591,3 +591,137 @@ class TestCheckRequirements:
 
         inquiries = runner.check_requirements(Stage.TREATMENT, session)
         assert len(inquiries) == 0
+
+
+# ── Session.summary() tests ───────────────────────────────────────
+
+
+class TestSessionSummary:
+    def test_summary_empty_session(self, tmp_path: Path) -> None:
+        """
+        title: summary() on a fresh session should show all-zero counts.
+        parameters:
+          tmp_path:
+            type: Path
+        """
+        path = tmp_path / 'session.parquet'
+        session = Session.create(path)
+
+        result = session.summary()
+
+        assert result['session_id'] == 'session'
+        assert result['language'] == 'en'
+        assert result['clinical_data_fields'] == 0
+        assert result['stages_completed'] == []
+        assert result['pending_inquiries'] == 0
+        assert result['required_inquiries'] == 0
+        assert result['total_events'] == 0
+
+    def test_summary_with_clinical_data(self, tmp_path: Path) -> None:
+        """
+        title: summary() should reflect the number of clinical data fields.
+        parameters:
+          tmp_path:
+            type: Path
+        """
+        path = tmp_path / 'patient_abc.parquet'
+        session = Session.create(path, language='pt')
+        session.set_clinical_data(
+            {'symptoms': 'bloating', 'age': 34, 'biological_sex': 'female'}
+        )
+
+        result = session.summary()
+
+        assert result['session_id'] == 'patient_abc'
+        assert result['language'] == 'pt'
+        assert result['clinical_data_fields'] == 3
+
+    def test_summary_after_stage_run(self, tmp_path: Path) -> None:
+        """
+        title: Completed stages should appear in summary and leave others pending.
+        parameters:
+          tmp_path:
+            type: Path
+        """
+        path = tmp_path / 'session.parquet'
+        session = Session.create(path)
+        session.set_clinical_data({'symptoms': 'fatigue'})
+
+        skill = _NoAssessSkill()
+        runner = StageRunner(skills=[skill])
+        runner.run_session(Stage.DIAGNOSIS, session)
+
+        result = session.summary()
+
+        assert Stage.DIAGNOSIS in result['stages_completed']
+        assert Stage.DIAGNOSIS not in result['stages_pending']
+        # All other standard stages should still be pending
+        assert Stage.SCREENING in result['stages_pending']
+        assert Stage.TREATMENT in result['stages_pending']
+
+    def test_summary_pending_inquiries_decrease(self, tmp_path: Path) -> None:
+        """
+        title: Inquiry counts in summary() should drop as answers are provided.
+        parameters:
+          tmp_path:
+            type: Path
+        """
+        path = tmp_path / 'session.parquet'
+        session = Session.create(path)
+        session.set_clinical_data({'symptoms': 'bloating'})
+
+        skill = _AssessingSkill()
+        runner = StageRunner(skills=[skill])
+        runner.check_requirements(Stage.DIAGNOSIS, session)
+
+        # Before answering: 2 inquiries (1 required, 1 deferred)
+        before = session.summary()
+        assert before['pending_inquiries'] == 2
+        assert before['required_inquiries'] == 1
+
+        # Provide the required answer
+        session.provide_answers({'dietary_history': 'high carb'})
+
+        # After answering: 1 inquiry left (the deferred one, not required)
+        after = session.summary()
+        assert after['pending_inquiries'] == 1
+        assert after['required_inquiries'] == 0
+
+    def test_summary_is_json_serializable(self, tmp_path: Path) -> None:
+        """
+        title: summary() return value should serialize to JSON without errors.
+        parameters:
+          tmp_path:
+            type: Path
+        """
+        import json
+
+        path = tmp_path / 'session.parquet'
+        session = Session.create(path)
+        session.set_clinical_data({'symptoms': 'headache'})
+
+        skill = _NoAssessSkill()
+        runner = StageRunner(skills=[skill])
+        runner.run_session(Stage.DIAGNOSIS, session)
+
+        result = session.summary()
+        serialized = json.dumps(result)
+        restored = json.loads(serialized)
+
+        assert restored['stages_completed'] == result['stages_completed']
+        assert restored['clinical_data_fields'] == result['clinical_data_fields']
+
+    def test_summary_session_id_is_filename_stem(self, tmp_path: Path) -> None:
+        """
+        title: session_id in summary() should match the parquet filename stem.
+        parameters:
+          tmp_path:
+            type: Path
+        """
+        path = tmp_path / 'visit_2026_07_08.parquet'
+        session = Session.create(path)
+
+        result = session.summary()
+
+        assert result['session_id'] == 'visit_2026_07_08'
+


### PR DESCRIPTION
## Pull Request description
This PR introduces a `summary()` method to the `Session` class to provide a snapshot of the current session state. This allows for quick retrieval of session metrics (like completed stages, pending inquiries, and clinical data field counts) without needing to manually replay all event rows or inspect the raw parquet file. 
The summary output is a fully JSON-serializable dictionary designed for easy logging, UI updates, and pipeline monitoring.
## How to test these changes
- `pytest tests/test_session.py::TestSessionSummary -vv`
- The new `TestSessionSummary` class contains 6 isolated tests that verify all aspects of the `summary()` output, including empty sessions, sessions with clinical data, and sessions after stage completion.
## Pull Request checklists
This PR is a:
- [ ] bug-fix
- [x] new feature
- [ ] maintenance
About this PR:
- [x] it includes tests.
- [x] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [x] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.
Author's checklist:
- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more complexity.
- [x] New and old tests passed locally.
## Additional information
The implementation utilizes explicit for-loops rather than dictionary-embedded comprehensions to bypass a known `mypy 1.20` internal assertion bug on Python 3.10. 
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved
```
