### PR TITLE
feat: add typed execution models and baseline pipeline tests

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -258,8 +258,8 @@ Key concepts:
 - **SkillRegistry** manages skill installation (from local paths or Git URLs)
   and loading. Skills are stored in `~/.hiperhealth/skills/` and activated via
   `runner.register("skill-name")`
-- **hiperhealth.yaml** is a metadata file every skill project must include,
-  declaring name, version, entry point, and stages
+- **skill.yaml** is a metadata file every skill project must include, declaring
+  name, version, entry point, and stages
 
 Source layout:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ package-dir = { "" = "src" }
 where = ["src"]
 
 [tool.setuptools.package-data]
-hiperhealth = ["py.typed", "skills/*/hiperhealth.yaml"]
+hiperhealth = ["py.typed", "skills/*/skill.yaml"]
 
 [project.optional-dependencies]
 notebook = [

--- a/src/hiperhealth/pipeline/__init__.py
+++ b/src/hiperhealth/pipeline/__init__.py
@@ -8,6 +8,13 @@ from hiperhealth.pipeline.context import (
     get_skill_ui_values,
 )
 from hiperhealth.pipeline.discovery import discover_skills
+from hiperhealth.pipeline.models import (
+    AgentStep,
+    AgentStepResult,
+    ExecutionStep,
+    PromptFragment,
+    SkillResult,
+)
 from hiperhealth.pipeline.registry import (
     AvailableSkillRecord,
     ChannelManifest,
@@ -30,14 +37,18 @@ from hiperhealth.pipeline.skill_app import (
 from hiperhealth.pipeline.stages import Stage
 
 __all__ = [
+    'AgentStep',
+    'AgentStepResult',
     'AuditEntry',
     'AvailableSkillRecord',
     'BaseSkill',
     'ChannelManifest',
     'ChannelRecord',
+    'ExecutionStep',
     'Inquiry',
     'InstalledSkillRecord',
     'PipelineContext',
+    'PromptFragment',
     'RegistryState',
     'Session',
     'Skill',
@@ -45,6 +56,7 @@ __all__ = [
     'SkillManifest',
     'SkillMetadata',
     'SkillRegistry',
+    'SkillResult',
     'SkillSummary',
     'SkillUIAction',
     'SkillUIPhase',

--- a/src/hiperhealth/pipeline/models.py
+++ b/src/hiperhealth/pipeline/models.py
@@ -1,0 +1,124 @@
+"""
+title: Pydantic schemas for the execution pipeline.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+
+class SkillResult(BaseModel):
+    """
+    title: The standardized result of a single skill execution.
+    attributes:
+      stage:
+        type: str
+      skill_name:
+        type: str
+      status:
+        type: Literal[succeeded, failed, skipped]
+      summary:
+        type: str
+      data:
+        type: dict[str, Any]
+      prompt_fragment:
+        type: str | None
+    """
+
+    stage: str
+    skill_name: str
+    status: Literal['succeeded', 'failed', 'skipped']
+    summary: str = ''
+    data: dict[str, Any] = {}
+    prompt_fragment: str | None = None
+
+
+class PromptFragment(BaseModel):
+    """
+    title: A piece of text contributed by a skill for the final prompt.
+    attributes:
+      stage:
+        type: str
+      skill_name:
+        type: str
+      title:
+        type: str
+      content:
+        type: str
+      priority:
+        type: int
+      include_in_final_prompt:
+        type: bool
+    """
+
+    stage: str
+    skill_name: str
+    title: str
+    content: str
+    priority: int = 100
+    include_in_final_prompt: bool = True
+
+
+class ExecutionStep(BaseModel):
+    """
+    title: Event log record tracking step-level pipeline execution.
+    attributes:
+      run_id:
+        type: str
+      stage:
+        type: str
+      skill_name:
+        type: str
+      hook:
+        type: str
+      attempt:
+        type: int
+      input_hash:
+        type: str
+      status:
+        type: Literal[started, completed, failed, skipped]
+      error_data:
+        type: dict[str, Any] | None
+    """
+
+    run_id: str
+    stage: str
+    skill_name: str
+    hook: str
+    attempt: int = 1
+    input_hash: str
+    status: Literal['started', 'completed', 'failed', 'skipped']
+    error_data: dict[str, Any] | None = None
+
+
+class AgentStep(BaseModel):
+    """
+    title: Sub-step tracked by complex multi-agent skills.
+    attributes:
+      name:
+        type: str
+      description:
+        type: str
+    """
+
+    name: str
+    description: str
+
+
+class AgentStepResult(BaseModel):
+    """
+    title: The outcome of an internal sub-step inside an agent skill.
+    attributes:
+      name:
+        type: str
+      status:
+        type: Literal[succeeded, failed, skipped]
+      data:
+        type: dict[str, Any]
+    """
+
+    name: str
+    status: Literal['succeeded', 'failed', 'skipped']
+    data: dict[str, Any] = {}

--- a/tests/test_pipeline_baseline.py
+++ b/tests/test_pipeline_baseline.py
@@ -1,0 +1,116 @@
+"""
+title: Baseline tests documenting current pipeline execution behavior.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hiperhealth.pipeline import (
+    BaseSkill,
+    PipelineContext,
+    SkillMetadata,
+    Stage,
+    StageRunner,
+)
+from hiperhealth.pipeline.session import Session
+
+
+class _DummySkillA(BaseSkill):
+    def __init__(self) -> None:
+        """
+        title: Initialize the dummy skill A.
+        """
+        super().__init__(
+            SkillMetadata(
+                name='test.skill_a',
+                stages=(Stage.DIAGNOSIS,),
+            )
+        )
+
+    def execute(self, stage: str, ctx: PipelineContext) -> PipelineContext:
+        """
+        title: Execute dummy skill A.
+        parameters:
+          stage:
+            type: str
+          ctx:
+            type: PipelineContext
+        returns:
+          type: PipelineContext
+        """
+        ctx.results[stage] = {'source': 'Skill A'}
+        return ctx
+
+
+class _DummySkillB(BaseSkill):
+    def __init__(self) -> None:
+        """
+        title: Initialize the dummy skill B.
+        """
+        super().__init__(
+            SkillMetadata(
+                name='test.skill_b',
+                stages=(Stage.DIAGNOSIS,),
+            )
+        )
+
+    def execute(self, stage: str, ctx: PipelineContext) -> PipelineContext:
+        """
+        title: Execute dummy skill B.
+        parameters:
+          stage:
+            type: str
+          ctx:
+            type: PipelineContext
+        returns:
+          type: PipelineContext
+        """
+        ctx.results[stage] = {'source': 'Skill B'}
+        return ctx
+
+
+class TestStageRunnerBaseline:
+    def test_overwrite_flaw_baseline(self) -> None:
+        """
+        title: Document the overwrite flaw where Skill B erases Skill A.
+        """
+        runner = StageRunner(skills=[_DummySkillA(), _DummySkillB()])
+        ctx = PipelineContext()
+        ctx = runner.run(Stage.DIAGNOSIS, ctx)
+
+        # Document the current flaw: Skill A's result is gone
+        assert ctx.results[Stage.DIAGNOSIS] == {'source': 'Skill B'}
+
+    def test_coarse_stage_logging_baseline(self, tmp_path: Any) -> None:
+        """
+        title: Document that the runner only logs coarse stage completion.
+        parameters:
+          tmp_path:
+            type: Any
+        """
+        session_path = tmp_path / 'test_session.parquet'
+        session = Session(session_path)
+
+        runner = StageRunner(skills=[_DummySkillA(), _DummySkillB()])
+
+        # Run the session
+        runner.run_session(Stage.DIAGNOSIS, session)
+
+        # Load the events directly from the session
+        # The session class uses a protected _events property
+        # internally for the raw list
+        events = getattr(session, '_events', [])
+        if not events:
+            # Try reloading it to populate _events if necessary
+            session._load()
+            events = getattr(session, '_events', [])
+
+        # We expect a 'stage_started' and a 'stage_completed' event
+        event_types = [e['event_type'] for e in events]
+        assert 'stage_started' in event_types
+        assert 'stage_completed' in event_types
+
+        # Document the current flaw: No per-skill events are recorded
+        assert 'skill_started' not in event_types
+        assert 'skill_completed' not in event_types


### PR DESCRIPTION
**1. Created Typed Execution Models**
Created a new file src/hiperhealth/pipeline/models.py and exported its contents in __init__.py. This lays the foundation for our resumable pipeline by defining the strict blueprints for the data:

- SkillResult: A standardized container for skill outputs.
- PromptFragment: A structured piece of text contributed by a skill.
- ExecutionStep: The detailed log record for step-level events.
- AgentStep & AgentStepResult: Models for the optional multi-agent protocol.

**2. Added Baseline Tests**
Created a new test file tests/test_pipeline_baseline.py containing two tests to document the current flaws have to be fixed:

- test_overwrite_flaw_baseline: Proves that when two skills run in the same stage, the second skill completely deletes/overwrites the first skill's results in the shared dictionary.
- test_coarse_stage_logging_baseline: Proves that the current session runner only logs stage_started and stage_completed, and is completely blind to individual skill events.
<img width="1472" height="191" alt="image" src="https://github.com/user-attachments/assets/805e2db2-ef46-4220-8940-a698ce8804e2" />

**3. Fixed Packaging and Documentation**
Fixed a bug in pyproject.toml where the package data was incorrectly looking for hiperhealth.yaml instead of skill.yaml.
Fixed the corresponding typo in the contributor documentation so future developers don't get confused.